### PR TITLE
FhirPath functions documentation

### DIFF
--- a/onfhir-path/pom.xml
+++ b/onfhir-path/pom.xml
@@ -32,6 +32,18 @@
                 <artifactId>scala-maven-plugin</artifactId>
                 <configuration>
                     <compileOrder>JavaThenScala</compileOrder>
+                    <launchers>
+                        <!-- Run io.onfhir.path.validation.ValidateFhirPathFunctionLibraries to validate that each
+                         FhirPath function is annotated with io.onfhir.path.annotation.FhirPathFunction -->
+                        <launcher>
+                            <id>validateFhirPathFunctionLibraries</id>
+                            <mainClass>io.onfhir.path.validation.ValidateFhirPathFunctionLibraries</mainClass>
+                            <!-- List of packages which include the FhirPath function libraries -->
+                            <args>
+                                <arg>io.onfhir.path</arg>
+                            </args>
+                        </launcher>
+                    </launchers>
                 </configuration>
                 <executions>
                     <execution>
@@ -52,6 +64,15 @@
                         <phase>process-resources</phase>
                         <goals>
                             <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <!-- In 'install' phase, execute 'run' goal which runs io.onfhir.path.validation.ValidateFhirPathFunctionLibraries
+                     to validate FhirPath libraries -->
+                    <execution>
+                        <id>run</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -112,6 +133,11 @@
             <groupId>org.specs2</groupId>
             <artifactId>specs2-junit_${scala.binary.version}</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <!-- Reflections -->
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala
@@ -4,6 +4,10 @@ import io.onfhir.path.grammar.FhirPathExprParser.ExpressionContext
 
 import java.lang.reflect.InvocationTargetException
 
+import io.onfhir.path.annotation.FhirPathFunction
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe._
+
 /**
  * Abstract class to implement for external function libraries
  */
@@ -13,6 +17,30 @@ abstract class AbstractFhirPathFunctionLibrary {
    * @return
    */
   def getFunctionSignatures():Seq[(String, Int)] = getClass.getMethods.filterNot(_.getName.startsWith("$anonfun$")).map(m => m.getName -> m.getParameterCount).toSeq
+
+  /**
+   * Returns documentations of functions in this library. It searches for the methods having FhirPathFunction annotation
+   * and returns them.
+   *
+   * @return a list of FhirPathFunction representing the documentation of functions
+   * */
+  def getFunctionDocumentation():Seq[FhirPathFunction] = currentMirror.classSymbol(Class.forName(getClass.getName))
+      .toType
+      .decls
+      // filter the methods having FhirPathFunction annotation
+      .filter(symbol => {
+        symbol.isMethod && symbol.annotations.exists(_.tree.tpe =:= typeOf[FhirPathFunction])
+      })
+      .map(method => {
+        // retrieve annotation fields
+        val annotationFields = method.annotations
+          .find(_.tree.tpe =:= typeOf[FhirPathFunction]).head
+          .tree.children.tail
+          .collect({ case Literal(Constant(s: String)) => s })
+        // create an instance of FhirPathFunction
+        new FhirPathFunction(annotationFields.headOption.get,annotationFields.lift(1).get,annotationFields.lift(2).get,annotationFields.lift(3).get)
+      }).toSeq
+
   /**
    * Method that will be used to call a FHIR Path function from the function library
    * Function library should define the function handlers as public methods with the name of the function that gets 0 or more ExpressionContext as parameters and return Seq of FhirPathResult

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathAggFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathAggFunctions.scala
@@ -1,5 +1,6 @@
 package io.onfhir.path
 
+import io.onfhir.path.annotation.FhirPathFunction
 import io.onfhir.path.grammar.FhirPathExprParser.ExpressionContext
 import org.json4s.JsonAST.JObject
 
@@ -14,6 +15,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * Sum of the input numeric values, 0 if input list is empty
    * @return
    */
+  @FhirPathFunction(documentation = "Returns sum of the input numeric values, 0 if input list is empty. Ex: valueQuantity.value.sum()",
+    insertText = "agg:sum()",detail = "agg", label = "agg:sum")
   def sum():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathNumber]))
       throw new FhirPathException(s"Invalid function call 'sum', one of the input values is not a numeric value!")
@@ -34,6 +37,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @param expr Expression to calculate the sum
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the sum of the values after executing the expression on given input values. Ex: sum(valueQuantity.value)",
+    insertText = "agg:sum(<expr>)",detail = "agg", label = "agg:sum")
   def sum(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results = current.map(c => {
       val result = new FhirPathExpressionEvaluator(context, Seq(c)).visit(expr)
@@ -53,6 +58,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @param expr  Expression to compute the average
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the average of given expression that returns a numeric value. Ex: avg($this.valueQuantity.value)",
+    insertText = "agg:avg(<expr>)",detail = "agg", label = "agg:avg")
   def avg(expr:ExpressionContext):Seq[FhirPathResult] = {
     if(current.isEmpty)
       Nil
@@ -64,6 +71,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * Average of the input numeric values
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the average of the input numeric values. Ex: valueQuantity.value.avg()",
+    insertText = "agg:avg()",detail = "agg", label = "agg:avg")
   def avg():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathNumber]))
       throw new FhirPathException(s"Invalid function call 'avg' on non numeric content!")
@@ -79,6 +88,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * Get the minimum of the input comparable values (numeric, dateTime
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the minimum of the input comparable values. Ex: min($this.valueQuantity.value)",
+    insertText = "agg:min()",detail = "agg", label = "agg:min")
   def min():Seq[FhirPathResult] = {
     if(current.exists(c => c.isInstanceOf[FhirPathComplex] || c.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException(s"Invalid function call 'min' on non comparable values!")
@@ -99,6 +110,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @param expr  Expression to calculate
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the minimum of given expression that returns a comparable value. Ex: min($this.valueQuantity.value)",
+    insertText = "agg:min(<expr>)",detail = "agg", label = "agg:min")
   def min(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results =
       current
@@ -122,6 +135,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @param expr  Expression to calculate
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the maximum of given expression that returns a comparable value. Ex: max($this.valueQuantity.value)",
+    insertText = "agg:max(<expr>)",detail = "agg", label = "agg:max")
   def max(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results = current
       .flatMap(c => {
@@ -143,6 +158,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * Getting the maximum of given input values
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the maximum of given input values. Ex: valueQuantity.value.max()",
+    insertText = "agg:max()",detail = "agg", label = "agg:max")
   def max():Seq[FhirPathResult] = {
     if(current.exists(c => c.isInstanceOf[FhirPathComplex] || c.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException(s"Invalid function call 'max' on non comparable values!")
@@ -163,6 +180,8 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @param aggregateExpr   Aggregation expression
    * @return                A list of special JSON Objects with field 'bucket' indicating the key for the bucket and 'agg' indicating the resulting aggregated value
    */
+  @FhirPathFunction(documentation = "Groups the values based on some expression returning a key and apply the aggregation to each group. Ex: groupBy(Condition.subject.reference.substring(8),count())",
+    insertText = "agg:groupBy(<groupByExpr>,<aggregateExpr>)",detail = "agg", label = "agg:groupBy")
   def groupBy(groupByExpr:ExpressionContext, aggregateExpr:ExpressionContext):Seq[FhirPathResult] = {
     if(!current.forall(_.isInstanceOf[FhirPathComplex]))
       throw new FhirPathException("Invalid function call 'groupBy' on current value! The data type for current value should be complex object!")

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathFunctionEvaluator.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathFunctionEvaluator.scala
@@ -2,6 +2,7 @@ package io.onfhir.path
 
 import java.time.{LocalDate, LocalDateTime, LocalTime, Year, YearMonth, ZonedDateTime}
 import io.onfhir.api.util.FHIRUtil
+import io.onfhir.path.annotation.FhirPathFunction
 import io.onfhir.path.grammar.FhirPathExprParser.ExpressionContext
 import org.apache.commons.text.StringEscapeUtils
 import org.json4s.JsonAST.JObject
@@ -26,6 +27,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @param params     Supplied parameters
     * @return
     */
+  @FhirPathFunction(documentation = "Calls the specified function with parameters",
+    insertText = "callFunction(<library-prefix>,<function-name>,<params>)", detail = "", label = "callFunction")
   def callFunction(fprefix:Option[String], fname:String, params:Seq[ExpressionContext]):Seq[FhirPathResult] = {
     fprefix match {
       //It is an original FHIR Path function or calling it without specificying a prefix
@@ -65,6 +68,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * Resolve a reference
    * @return
    */
+  @FhirPathFunction(documentation = "Resolves a reference",
+    insertText = "resolve()", detail = "", label = "resolve")
   def resolve():Seq[FhirPathResult] = {
     val fhirReferences = current.map {
       case FhirPathString(uri) => FHIRUtil.parseCanonicalReference(uri)
@@ -82,6 +87,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @param urlExp
    * @return
    */
+  @FhirPathFunction(documentation = "Returns a specific extension",
+    insertText = "extension(<urlExp>)", detail = "", label = "extension")
   def extension(urlExp:ExpressionContext):Seq[FhirPathResult] = {
     val url = new FhirPathExpressionEvaluator(context, current).visit(urlExp)
     if(url.length != 1 || !url.head.isInstanceOf[FhirPathString])
@@ -97,8 +104,14 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   /**
     * Type functions, for these basic casting or type checking are done before calling the function on the left expression
     */
+  @FhirPathFunction(documentation = "Returns a collection that contains all items in the input collection that are of the given type or a subclass thereof.",
+    insertText = "ofType(<expr>)", detail = "", label = "ofType")
   def ofType(typ:ExpressionContext):Seq[FhirPathResult] = current
+  @FhirPathFunction(documentation = "If the left operand is a collection with a single item and the second operand is an identifier, this operator returns the value of the left operand if it is of the type specified in the second operand, or a subclass thereof. ",
+    insertText = "as(<expr>)", detail = "", label = "as")
   def as(typ:ExpressionContext):Seq[FhirPathResult] = current
+  @FhirPathFunction(documentation = "If the left operand is a collection with a single item and the second operand is a type identifier, this operator returns true if the type of the left operand is the type specified in the second operand, or a subclass thereof. ",
+    insertText = "is(<expr>)", detail = "", label = "is")
   def is(typ:ExpressionContext):Seq[FhirPathResult] = {
     current.length match {
       case 0 => Seq(FhirPathBoolean(false))
@@ -112,8 +125,12 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Existence functions http://hl7.org/fhirpath/#existence
     * @return
     */
+  @FhirPathFunction(documentation = "Returns true if the input collection is empty ({ }) and false otherwise.",
+    insertText = "empty()", detail = "", label = "empty")
   def empty():Seq[FhirPathResult] = Seq(FhirPathBoolean(current.isEmpty))
 
+  @FhirPathFunction(documentation = "Returns true if the input collection evaluates to false, and false if it evaluates to true.",
+    insertText = "not()", detail = "", label = "not")
   def not():Seq[FhirPathResult] = current match {
     case Nil => Nil
     case Seq(FhirPathBoolean(b)) => Seq(FhirPathBoolean(!b))
@@ -135,9 +152,14 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
     Seq(FhirPathBoolean(result))
   }
+  @FhirPathFunction(documentation = "Returns true if the collection has any elements satisfying the criteria, and false otherwise.",
+    insertText = "exists(<expr>)", detail = "", label = "exists")
   def exists(expr:ExpressionContext):Seq[FhirPathResult] = exists(Some(expr))
+  @FhirPathFunction(documentation = "Returns true if the collection has any elements, and false otherwise.",
+    insertText = "exists()", detail = "", label = "exists")
   def exists():Seq[FhirPathResult] = exists(None)
-
+  @FhirPathFunction(documentation = "Returns true if for every element in the input collection, criteria evaluates to true.",
+    insertText = "all(<criteria>)", detail = "", label = "all")
   def all(criteria:ExpressionContext):Seq[FhirPathResult] = {
     val result =
       current
@@ -150,41 +172,47 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
         })
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if all the items are true.",
+    insertText = "allTrue()", detail = "", label = "allTrue")
   def allTrue():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'allTrue' should run on collection of FHIR Path boolean values!!!")
     val result = current.forall(c => c.asInstanceOf[FhirPathBoolean].b)
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if any of the items are true.",
+    insertText = "anyTrue()", detail = "", label = "anyTrue")
   def anyTrue():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'anyTrue' should run on collection of FHIR Path boolean values!!!")
     val result = current.exists(c => c.asInstanceOf[FhirPathBoolean].b)
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if all the items are false.",
+    insertText = "allFalse()", detail = "", label = "allFalse")
   def allFalse():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'allFalse' should run on collection of FHIR Path boolean values!!!")
     val result = current.forall(c => !c.asInstanceOf[FhirPathBoolean].b)
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if any of the items are false",
+    insertText = "anyFalse()", detail = "", label = "anyFalse")
   def anyFalse():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'anyFalse' should run on collection of FHIR Path boolean values!!!")
     val result = current.exists(c => !c.asInstanceOf[FhirPathBoolean].b)
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Returns true if all items in the input collection are members of the collection passed as the other argument.",
+    insertText = "subsetOf(<other>)", detail = "", label = "subsetOf")
   def subsetOf(other:ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     val result = current.forall(c => otherCollection.exists(o => c.isEqual(o).getOrElse(false)))
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Returns true if all items in the collection passed as the other argument are members of the input collection.",
+    insertText = "supersetOf(<other>)", detail = "", label = "supersetOf")
   def supersetOf(other:ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     val result =
@@ -194,15 +222,18 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
         otherCollection.forall(o => current.exists(c => c.isEqual(o).getOrElse(false)))
     Seq(FhirPathBoolean(result))
   }
-
+  @FhirPathFunction(documentation = "Returns true if all the items in the input collection are distinct.",
+    insertText = "isDistinct()", detail = "", label = "isDistinct")
   def isDistinct():Seq[FhirPathResult] = {
     Seq(FhirPathBoolean(current.distinct.length == current.length))
   }
-
+  @FhirPathFunction(documentation = "Returns a collection containing only the unique items in the input collection. ",
+    insertText = "distinct()", detail = "", label = "distinct")
   def distinct():Seq[FhirPathResult] = {
     current.distinct
   }
-
+  @FhirPathFunction(documentation = "Returns the integer count of the number of items in the input collection.",
+    insertText = "count()", detail = "", label = "count")
   def count():Seq[FhirPathResult] = {
     Seq(FhirPathNumber(current.length))
   }
@@ -210,6 +241,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   /**
     * Filtering and projection http://hl7.org/fhirpath/#filtering-and-projection
     */
+  @FhirPathFunction(documentation = "Returns a collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.",
+    insertText = "where(<criteria>)", detail = "", label = "where")
   def where(criteria : ExpressionContext):Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -224,6 +257,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       .map(_._1)
   }
 
+  @FhirPathFunction(documentation = "Evaluates the projection expression for each item in the input collection.",
+    insertText = "select(<projection>)", detail = "", label = "select")
   def select(projection: ExpressionContext):Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -232,7 +267,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
         r
       })
   }
-
+  @FhirPathFunction(documentation = "A version of select that will repeat the projection and add it to the output collection",
+    insertText = "repeat(<projection>)", detail = "", label = "repeat")
   def repeat(projection: ExpressionContext):Seq[FhirPathResult] = {
     val firstResults = select(projection)
     if(firstResults.nonEmpty)
@@ -244,6 +280,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   /**
     * Subsetting http://hl7.org/fhirpath/#subsetting
     */
+  @FhirPathFunction(documentation = "Returns the single item in the input if there is just one item.",
+    insertText = "single()", detail = "", label = "single")
   def single():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -251,10 +289,17 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       case _ => throw new FhirPathException(s"Function 'single' is called on a multi item collection $current!!!")
     }
   }
-
+  @FhirPathFunction(documentation = "Returns a collection containing only the first item in the input collection.",
+    insertText = "first()", detail = "", label = "first")
   def first():Seq[FhirPathResult] = current.headOption.toSeq
+  @FhirPathFunction(documentation = "Returns a collection containing only the last item in the input collection. Will return an empty collection if the input collection has no items.",
+    insertText = "last()", detail = "", label = "last")
   def last():Seq[FhirPathResult] = current.lastOption.toSeq
+  @FhirPathFunction(documentation = "Returns a collection containing all but the first item in the input collection.",
+    insertText = "tail()", detail = "", label = "tail")
   def tail():Seq[FhirPathResult] = if(current.isEmpty) Nil else current.tail
+  @FhirPathFunction(documentation = "Returns a collection containing all but the first num items in the input collection. ",
+    insertText = "skip(<numExpr>)", detail = "", label = "skip")
   def skip(numExpr:ExpressionContext):Seq[FhirPathResult] = {
     val numValue = new FhirPathExpressionEvaluator(context, current).visit(numExpr)
     if(numValue.length != 1 || !numValue.head.isInstanceOf[FhirPathNumber])
@@ -271,6 +316,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     else
       current.drop(i)
   }
+  @FhirPathFunction(documentation = "Returns a collection containing the first num items in the input collection, or less if there are less than num items. ",
+    insertText = "take(<numExpr>)", detail = "", label = "take")
   def take(numExpr:ExpressionContext):Seq[FhirPathResult] = {
     val numValue = new FhirPathExpressionEvaluator(context, current).visit(numExpr)
     if(numValue.length != 1 || !numValue.head.isInstanceOf[FhirPathNumber])
@@ -283,12 +330,14 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     else
       current.take(i)
   }
-
+  @FhirPathFunction(documentation = "Returns the set of elements that are in both collections. ",
+    insertText = "intersect(<otherCollExpr>)", detail = "", label = "intersect")
   def intersect(otherCollExpr:ExpressionContext):Seq[FhirPathResult] = {
     val otherSet = new FhirPathExpressionEvaluator(context, current).visit(otherCollExpr)
     current.filter(c => otherSet.exists(o => c.isEqual(o).getOrElse(false))).distinct
   }
-
+  @FhirPathFunction(documentation = "Returns the set of elements that are not in the other collection. ",
+    insertText = "exclude(<otherCollExpr>)", detail = "", label = "exclude")
   def exclude(otherCollExpr:ExpressionContext):Seq[FhirPathResult] = {
     val otherSet = new FhirPathExpressionEvaluator(context, current).visit(otherCollExpr)
     current.filterNot(c => otherSet.exists(o => c.isEqual(o).getOrElse(false))).distinct
@@ -300,6 +349,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the absolute value of the input.",
+    insertText = "abs()", detail = "", label = "abs")
   def abs():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -315,6 +366,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the first integer greater than or equal to the input.",
+    insertText = "ceiling()", detail = "", label = "ceiling")
   def ceiling():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -331,6 +384,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns e raised to the power of the input.",
+    insertText = "exp()", detail = "", label = "exp")
   def exp():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -346,6 +401,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the first integer less than or equal to the input.",
+    insertText = "floor()", detail = "", label = "floor")
   def floor():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -362,6 +419,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the natural logarithm of the input (i.e. the logarithm base e).",
+    insertText = "ln()", detail = "", label = "ln")
   def ln():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -380,6 +439,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @param baseExp
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the logarithm base base of the input number.",
+    insertText = "log(<baseExp>)", detail = "", label = "log")
   def log(baseExp:ExpressionContext):Seq[FhirPathResult] = {
     val baseResult = new FhirPathExpressionEvaluator(context, current).visit(baseExp)
     if(baseResult.length != 1 || !baseResult.head.isInstanceOf[FhirPathNumber])
@@ -401,6 +462,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @param exponentExpr
    * @return
    */
+  @FhirPathFunction(documentation = "Raises a number to the exponent power.",
+    insertText = "power(<exponentExpr>)", detail = "", label = "power")
   def power(exponentExpr:ExpressionContext):Seq[FhirPathResult] = {
     val exponentResult = new FhirPathExpressionEvaluator(context, current).visit(exponentExpr)
     if(exponentResult.length != 1 || !exponentResult.head.isInstanceOf[FhirPathNumber])
@@ -420,6 +483,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Rounds the decimal to the nearest whole number using a traditional round.",
+    insertText = "round()", detail = "", label = "round")
   def round():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -437,6 +502,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @param precisionExpr
    * @return
    */
+  @FhirPathFunction(documentation = "Rounds the decimal to the nearest whole number using a traditional round.",
+    insertText = "round(<precisionExpr>)", detail = "", label = "round")
   def round(precisionExpr:ExpressionContext):Seq[FhirPathResult] = {
     val precisionResult = new FhirPathExpressionEvaluator(context, current).visit(precisionExpr)
     precisionResult match {
@@ -460,6 +527,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the square root of the input number as a Decimal.",
+    insertText = "sqrt()", detail = "", label = "sqrt")
   def sqrt():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -485,6 +554,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the integer portion of the input.",
+    insertText = "truncate()", detail = "", label = "truncate")
   def truncate():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -500,6 +571,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @param other
     * @return
     */
+  @FhirPathFunction(documentation = "Merges the input and other collections into a single collection without eliminating duplicate values.",
+    insertText = "combine(<other>)", detail = "", label = "combine")
   def combine(other : ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     current ++ otherCollection
@@ -508,6 +581,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   /**
     * Conversion functions http://hl7.org/fhirpath/#conversion
     */
+  @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument. Otherwise, it returns otherwise-result",
+    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif")
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext, otherwiseResult: Option[ExpressionContext]):Seq[FhirPathResult] = {
     val criteriaResult = new FhirPathExpressionEvaluator(context, current).visit(criterium)
     val conditionResult = criteriaResult match {
@@ -520,7 +595,11 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     else
       otherwiseResult.map(ore =>  new FhirPathExpressionEvaluator(context, current).visit(ore)).getOrElse(Nil)
   }
+  @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument. Otherwise, it returns otherwise-result",
+    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif")
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext, otherwiseResult: ExpressionContext) :Seq[FhirPathResult]= iif(criterium, trueResult, Some(otherwiseResult))
+  @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument.",
+    insertText = "iif(<criterium>,<trueResult>)", detail = "", label = "iif")
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext):Seq[FhirPathResult] = iif(criterium, trueResult, None)
 
 
@@ -528,6 +607,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * Integer conversion function
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to an integer.",
+    insertText = "toInteger()", detail = "", label = "toInteger")
   def toInteger():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -547,6 +628,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * Decimal conversion function
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to a decimal.",
+    insertText = "toDecimal()", detail = "", label = "toDecimal")
   def toDecimal():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -567,6 +650,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * Check if the current item can be converted to decimal
    * @return
    */
+  @FhirPathFunction(documentation = "Checks if the current item can be converted to decimal",
+    insertText = "convertsToDecimal()", detail = "", label = "convertsToDecimal")
   def convertsToDecimal():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -587,6 +672,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * Boolean conversion function
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to a boolean.",
+    insertText = "toBoolean()", detail = "", label = "toBoolean")
   def toBoolean():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -616,6 +703,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * Date conversion function
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to a date.",
+    insertText = "toDate()", detail = "", label = "toDate")
   def toDate():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -635,6 +724,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * DateTime conversion function
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to a datetime.",
+    insertText = "toDateTime()", detail = "", label = "toDateTime")
   def toDateTime():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -650,7 +741,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       case _ => throw new FhirPathException(s"Invalid function call 'toDateTime' on multiple values!!!")
     }
   }
-
+  @FhirPathFunction(documentation = "Converts it to a quantity.",
+    insertText = "toQuantity()", detail = "", label = "toQuantity")
   def toQuantity():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -663,7 +755,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       case _ => throw new FhirPathException(s"Invalid function call 'toQuantity' on multiple values!!!")
     }
   }
-
+  @FhirPathFunction(documentation = "Converts it to a quantity.",
+    insertText = "toQuantity(<unitExpr>)", detail = "", label = "toQuantity")
   def toQuantity(unitExpr:ExpressionContext):Seq[FhirPathResult] = {
     val unitValue = new FhirPathExpressionEvaluator(context, current).visit(unitExpr)
     if(!unitValue.forall(_.isInstanceOf[FhirPathString]))
@@ -685,6 +778,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * String conversion function
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to a string",
+    insertText = "toString()", detail = "", label = "toString")
   def _toString():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -699,7 +794,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       case _ => throw new FhirPathException(s"Invalid function call '_toString' on multiple values !!!")
     }
   }
-
+  @FhirPathFunction(documentation = "Converts a quantity to a FHIR Path Object type (JSON).",
+    insertText = "toComplex()", detail = "", label = "toComplex")
   def toComplex():Seq[FhirPathResult] = {
     current match {
       case Seq(q:FhirPathQuantity) => Seq(FhirPathComplex(q.toJson.asInstanceOf[JObject]))
@@ -715,7 +811,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   private def checkSingleString() =
     if(current.length > 1 || current.headOption.exists(!_.isInstanceOf[FhirPathString]))
       throw new FhirPathException("Invalid function call on multi item collection or non-string value!")
-
+  @FhirPathFunction(documentation = "Returns the 0-based index of the first position substring is found in the input string, or -1 if it is not found. Ex: 'abcdefg'.indexOf('bc')",
+    insertText = "indexOf(<substringExpr>)", detail = "", label = "indexOf")
   def indexOf(substringExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -725,7 +822,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       }
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3,1)",
+    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring")
   def substring(startExpr : ExpressionContext, lengthExpr:Option[ExpressionContext]):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -750,9 +848,14 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       }
     }).getOrElse(Nil)
   }
+  @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3)",
+    insertText = "substring(<startExpr>)", detail = "", label = "substring")
   def substring(startExpr:ExpressionContext):Seq[FhirPathResult] = substring(startExpr, None)
+  @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3,2)",
+    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring")
   def substring(startExpr:ExpressionContext, lengthExpr:ExpressionContext):Seq[FhirPathResult] = substring(startExpr, Some(lengthExpr))
-
+  @FhirPathFunction(documentation = "Returns true when the input string starts with the given prefix. Ex: 'abcdefg'.startsWith('abc')",
+    insertText = "startsWith(<prefixExpr>)", detail = "", label = "startsWith")
   def startsWith(prefixExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -765,7 +868,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       }
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Returns true when the input string ends with the given suffix. Ex: 'abcdefg'.endsWith('efg')",
+    insertText = "endsWith(<suffixExpr>)", detail = "", label = "endsWith")
   def endsWith(suffixExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -775,7 +879,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       }
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Returns true when the given substring is a substring of the input string. Ex: 'abc'.contains('b')",
+    insertText = "contains(<substringExpr>)", detail = "", label = "contains")
   def _contains(substringExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -785,7 +890,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       }
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Returns the input string with all instances of pattern replaced with substitution. Ex: 'abcdefg'.replace('cde', '123')",
+    insertText = "replace(<patternExpr>,<substitutionExpr>)", detail = "", label = "replace")
   def replace(patternExpr : ExpressionContext, substitutionExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -802,7 +908,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       Seq(FhirPathString(c.asInstanceOf[FhirPathString].s.replace(pattern, substitution)))
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Returns true when the value matches the given regular expression.",
+    insertText = "matches(<regexExpr>)", detail = "", label = "matches")
   def matches(regexExpr : ExpressionContext):Seq[FhirPathResult] = {
     current.headOption.map(c => {
       new FhirPathExpressionEvaluator(context, current).visit(regexExpr) match {
@@ -822,7 +929,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       }
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Matches the input using the regular expression in regex and replaces each match with the substitution string.",
+    insertText = "replaceMatches(<regexExpr>,<substitutionExpr>)", detail = "", label = "replaceMatches")
   def replaceMatches(regexExpr : ExpressionContext, substitutionExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -839,7 +947,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       Seq(FhirPathString(c.asInstanceOf[FhirPathString].s.replaceAll(regex, substitution)))
     }).getOrElse(Nil)
   }
-
+  @FhirPathFunction(documentation = "Returns the length of the input string.",
+    insertText = "length()", detail = "", label = "length")
   def length():Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => Seq(FhirPathNumber(c.asInstanceOf[FhirPathString].s.length))).getOrElse(Nil)
@@ -848,13 +957,16 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   /**
     * Tree navigation function http://hl7.org/fhirpath/#tree-navigation
     */
+  @FhirPathFunction(documentation = "Returns a collection with all immediate child nodes of all items in the input collection. Ex: Questionnaire.children().select(item)",
+    insertText = "children()", detail = "", label = "children")
   def children():Seq[FhirPathResult] = {
     current
       .filter(_.isInstanceOf[FhirPathComplex])
       .map(_.asInstanceOf[FhirPathComplex])
       .flatMap(pc => pc.json.obj.map(_._2).flatMap(i => FhirPathValueTransformer.transform(i, context.isContentFhir)))
   }
-
+  @FhirPathFunction(documentation = "Returns a collection with all descendant nodes of all items in the input collection. Ex: Questionnaire.descendants().select(item)",
+    insertText = "descendants()", detail = "", label = "descendants")
   def descendants():Seq[FhirPathResult] = {
     val results = children()
     if(results.nonEmpty)
@@ -863,6 +975,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       results
   }
 
+  @FhirPathFunction(documentation = "Returns true if the input collection contains values",
+    insertText = "hasValue()", detail = "", label = "hasValue")
   def hasValue():Seq[FhirPathResult] = {
     Seq(FhirPathBoolean(current.nonEmpty))
   }
@@ -873,6 +987,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @param initValueExpr   Given initial value for aggregation
    * @return
    */
+  @FhirPathFunction(documentation = "Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Ex: value.aggregate($this + $total, 0)",
+    insertText = "aggregate(<aggExpr>,<initValueExpr>)", detail = "", label = "aggregate")
   def aggregate(aggExpr:ExpressionContext, initValueExpr:ExpressionContext):Seq[FhirPathResult] = {
     val initValue = new FhirPathExpressionEvaluator(context, current).visit(initValueExpr)
     if(initValue.length > 1)
@@ -905,6 +1021,8 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @param aggExpr Aggregation expression
    * @return
    */
+  @FhirPathFunction(documentation = "Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Ex: value.aggregate($this + $total)",
+    insertText = "aggregate(<aggExpr>)", detail = "", label = "aggregate")
   def aggregate(aggExpr:ExpressionContext):Seq[FhirPathResult] = {
       handleAggregate(context, aggExpr)
   }
@@ -912,14 +1030,20 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   /**
     * Utility functions http://hl7.org/fhirpath/#utility-functions
     */
+  @FhirPathFunction(documentation = "Returns the current date.",
+    insertText = "today()", detail = "", label = "today")
   def today():Seq[FhirPathResult] = Seq(FhirPathDateTime(LocalDate.now()))
+  @FhirPathFunction(documentation = "Returns the current date and time, including timezone offset.",
+    insertText = "now()", detail = "", label = "now")
   def now():Seq[FhirPathResult] = Seq(FhirPathDateTime(ZonedDateTime.now()))
-
+  @FhirPathFunction(documentation = "Adds a String representation of the input collection to the diagnostic log, using the name argument as the name in the log. Ex: contained.where(criteria).trace('unmatched').empty()",
+    insertText = "trace(<nameExpr>)", detail = "", label = "trace")
   def trace(nameExpr : ExpressionContext):Seq[FhirPathResult] = {
     //TODO log the current value with the given name
     current
   }
-
+  @FhirPathFunction(documentation = "Adds a String representation of the input collection to the diagnostic log, using the name argument as the name in the log. Ex: contained.where(criteria).trace('unmatched', id).empty()",
+    insertText = "trace(<nameExpr>,<othExpr>)", detail = "", label = "trace")
   def trace(nameExpr : ExpressionContext, othExpr:ExpressionContext):Seq[FhirPathResult] = {
     current
   }

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathIdentityServiceFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathIdentityServiceFunctions.scala
@@ -1,6 +1,7 @@
 package io.onfhir.path
 
 import io.onfhir.api.service.IFhirIdentityService
+import io.onfhir.path.annotation.FhirPathFunction
 import io.onfhir.path.grammar.FhirPathExprParser.ExpressionContext
 
 import scala.concurrent.Await
@@ -20,6 +21,8 @@ class FhirPathIdentityServiceFunctions(context: FhirPathEnvironment) extends Abs
    * @param identifierSystemExpr Business identifier system (Identifier.system)
    * @return Identifier for the resource e.g. Patient/455435464698
    */
+  @FhirPathFunction(documentation = "Resolves the given business identifier and return the FHIR Resource identifier (together with the resource type) by using the supplied identity service. Ex: idxs:resolveIdentifier('Patient', '12345', 'urn:oid:1.2.36.146.595.217.0.1')",
+    insertText = "idxs:resolveIdentifier(<resourceTypeExpr>,<identifierValueExpr>,<identifierSystemExpr>)",detail = "idxs", label = "idxs:resolveIdentifier")
   def resolveIdentifier(resourceTypeExpr: ExpressionContext, identifierValueExpr: ExpressionContext, identifierSystemExpr: Option[ExpressionContext]): Seq[FhirPathResult] = {
     val identityService = checkIdentityService()
 

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathNavFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathNavFunctions.scala
@@ -1,5 +1,6 @@
 package io.onfhir.path
 
+import io.onfhir.path.annotation.FhirPathFunction
 import io.onfhir.path.grammar.FhirPathExprParser.ExpressionContext
 
 /**
@@ -14,6 +15,8 @@ class FhirPathNavFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @param elseExpr
    * @return
    */
+  @FhirPathFunction(documentation = "If the current expression returns Nil, then evaluates the else expression from start, otherwise return current. Ex: startTime.nav:orElse(plannedTime)",
+    insertText = "nav:orElse(<expression>)",detail = "nav", label = "nav:orElse")
   def orElse(elseExpr:ExpressionContext):Seq[FhirPathResult] = {
     current match {
       case Nil =>

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathTerminologyServiceFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathTerminologyServiceFunctions.scala
@@ -3,6 +3,7 @@ package io.onfhir.path
 import akka.http.scaladsl.model.Uri
 import io.onfhir.api.service.IFhirTerminologyService
 import io.onfhir.api.util.FHIRUtil
+import io.onfhir.path.annotation.FhirPathFunction
 import io.onfhir.path.grammar.FhirPathExprParser.ExpressionContext
 import io.onfhir.util.JsonFormatter.formats
 import org.json4s.JsonAST.{JArray, JBool, JObject, JString}
@@ -28,6 +29,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param paramsExpr       A URL encoded string with other parameters for the validate-code operation (e.g. 'source=http://acme.org/valueset/23&target=http://acme.org/valueset/23')
    * @return
    */
+  @FhirPathFunction(documentation = "This calls the Terminology Service $translate operation. Ex: %terminologies.translate('http://aiccelerate.eu/fhir/ConceptMap/labResultsConceptMap', Observation.code, 'conceptMapVersion=1.0')",
+    insertText = "%terminologies.translate(<conceptMapExpr>,<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate")
   def translate(conceptMapExpr:ExpressionContext, codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     //Evaluate concept map url
@@ -86,6 +89,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param paramsExpr     A URL encoded string with other parameters for the validate-code operation (e.g. 'source=http://acme.org/valueset/23&target=http://acme.org/valueset/23')
    * @return
    */
+  @FhirPathFunction(documentation = "This calls the Terminology Service $translate operation without a concept map. Ex: %terminologies.translate(Observation.code, 'source=http://hus.fi/ValueSet/labResultCodes'&target=http://aiccelerate.eu/ValueSet/labResultCodes)",
+    insertText = "%terminologies.translate(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate")
   def translate(codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     // Evaluate code
@@ -143,6 +148,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param paramsExpr  Expression to evaluate a URL encoded string with other parameters for the lookup operation (e.g. 'date=2011-03-04&displayLanguage=en')
    * @return
    */
+  @FhirPathFunction(documentation = "This calls the Terminology Service $lookup operation. Ex: %terminologies.lookup(Observation.code.coding[0], 'displayLanguage=tr')",
+    insertText = "%terminologies.lookup(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.lookup")
   def lookup(codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     // Evaluate code
@@ -206,6 +213,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param displayLanguageExpr Expression to evaluate optional displayLanguage
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the display string in preferred language for the given code+system. Ex:trms:lookupDisplay('C12', 'http://hus.fi/CodeSystem/labResults', 'tr')",
+    insertText = "trms.lookupDisplay(<codeExpr>,<systemExpr>,<displayLanguageExpr>)",detail = "trms", label = "trms.lookupDisplay")
   def lookupDisplay(codeExpr:ExpressionContext, systemExpr:ExpressionContext, displayLanguageExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val code = evaluateToSingleString(codeExpr)
@@ -236,6 +245,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param conceptMapUrlExpr   Expression to evaluate the ConceptMap canonical url
    * @return
    */
+  @FhirPathFunction(documentation = "Translates the given Coding or CodeableConcept according to the given conceptMap. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://www.ncbi.nlm.nih.gov/clinvar')",
+    insertText = "trms.translateToCoding(<codingExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding")
   def translateToCoding(codingExpr:ExpressionContext, conceptMapUrlExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val codingResult = evaluateCodeExpr(codingExpr)
@@ -261,6 +272,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param conceptMapUrlExpr Expression to evaluate the ConceptMap canonical url
    * @return                  Matching codes (in Coding data type)
    */
+  @FhirPathFunction(documentation = "Translates the given code+system according to the given conceptMap. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://system', 'https://www.ncbi.nlm.nih.gov/clinvar')",
+    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding")
   def translateToCoding(codeExpr:ExpressionContext, systemExpr:ExpressionContext, conceptMapUrlExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val conceptMapUrl = evaluateToSingleString(conceptMapUrlExpr)
@@ -286,6 +299,8 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @param targetValueSetUrlExpr   Expression to evaluate to the target value set url
    * @return
    */
+  @FhirPathFunction(documentation = "Translates the given code+system according to the given source value set and optional target value set. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://system','https://sourceValue','https://targetValue')",
+    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<sourceValueSetUrlExpr>,<targetValueSetUrlExpr>)",detail = "trms", label = "trms.translateToCoding")
   def translateToCoding( codeExpr:ExpressionContext,
                          systemExpr:ExpressionContext,
                          sourceValueSetUrlExpr:ExpressionContext,

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathUtilFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathUtilFunctions.scala
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.{ChronoUnit, Temporal}
 import java.time._
 import java.util.UUID
+import io.onfhir.path.annotation.FhirPathFunction
 import scala.util.Try
 
 
@@ -24,6 +25,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    *
    * @return
    */
+  @FhirPathFunction(documentation = "Generates an UUID",
+    insertText = "utl:uuid()",detail = "utl", label = "utl:uuid")
   def uuid(): Seq[FhirPathResult] = {
     Seq(FhirPathString(UUID.randomUUID().toString))
   }
@@ -33,6 +36,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    *
    * @return
    */
+  @FhirPathFunction(documentation = "Checks whether the given string or character starts with or is a letter.",
+    insertText = "utl:isLetter()",detail = "utl", label = "utl:isLetter")
   def isLetter(): Seq[FhirPathResult] = {
     current match {
       case Seq(FhirPathString(l)) => Seq(FhirPathBoolean(l.head.isLetter))
@@ -48,6 +53,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @example ' ali  '.trim() --> 'ali'
    * @return
    */
+  @FhirPathFunction(documentation = "Trims the strings in the current set. Ex: ' ali  '.trim()",
+    insertText = "utl:trim()",detail = "utl", label = "utl:trim")
   def trim(): Seq[FhirPathResult] = {
     current.flatMap {
       case FhirPathString(s) =>
@@ -68,6 +75,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param ridExp          Resource identifier(s)
    * @return
    */
+  @FhirPathFunction(documentation = "Creates FHIR Reference object(s) with given resource type and id(s). Ex: utl:createFhirReference('Observation', id)",
+    insertText = "utl:createFhirReference(<resourceTypeExp>, <ridExp>)",detail = "utl", label = "utl:createFhirReference")
   def createFhirReference(resourceTypeExp: ExpressionContext, ridExp: ExpressionContext): Seq[FhirPathResult] = {
     val rids = new FhirPathExpressionEvaluator(context, current).visit(ridExp)
     if (!rids.forall(_.isInstanceOf[FhirPathString]))
@@ -94,6 +103,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param displayExpr Expression to give the display value (optional)
    * @return
    */
+  @FhirPathFunction(documentation = "Creates a FHIR Coding content with given system code and optional display. Ex: utl:createFhirCoding('http://snomed.info/sct', '246103008', 'Certainty')",
+    insertText = "utl:createFhirCoding(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCoding")
   def createFhirCoding(systemExp: ExpressionContext, codeExpr: ExpressionContext, displayExpr: ExpressionContext): Seq[FhirPathResult] = {
     val system = new FhirPathExpressionEvaluator(context, current).visit(systemExp)
     if (system.length > 1 || !system.forall(_.isInstanceOf[FhirPathString]))
@@ -130,6 +141,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param displayExpr Expression to give the display value (optional)
    * @return
    */
+  @FhirPathFunction(documentation = "Creates FHIR codeable concept. Ex: utl:createFhirCodeableConcept('http://snomed.info/sct', '246103008', 'Certainty')",
+    insertText = "utl:createFhirCodeableConcept(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCodeableConcept")
   def createFhirCodeableConcept(systemExp: ExpressionContext, codeExpr: ExpressionContext, displayExpr: ExpressionContext): Seq[FhirPathResult] = {
     val system = new FhirPathExpressionEvaluator(context, current).visit(systemExp)
     if (system.length > 1 || !system.forall(_.isInstanceOf[FhirPathString]))
@@ -173,6 +186,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param unitExpr  Expression for quantity unit
    * @return
    */
+  @FhirPathFunction(documentation = "Creates FHIR quantity. Ex: utl:createFhirQuantity(1, 'mg')",
+    insertText = "utl:createFhirQuantity(<value>, <unit>)",detail = "utl", label = "utl:createFhirQuantity")
   def createFhirQuantity(valueExpr: ExpressionContext, unitExpr: ExpressionContext): Seq[FhirPathResult] = {
     val value = handleFhirQuantityValue(valueExpr)
     val unit = new FhirPathExpressionEvaluator(context, current).visit(unitExpr)
@@ -194,6 +209,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param codeExpr   Expression to return the the unit
    * @return
    */
+  @FhirPathFunction(documentation = "Creates FHIR Quantity json object with given value, system and unit. Ex: utl:createFhirQuantity(15.2, %ucum, 'mg')",
+    insertText = "utl:createFhirQuantity(<valueExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity")
   def createFhirQuantity(valueExpr: ExpressionContext, systemExpr: ExpressionContext, codeExpr: ExpressionContext): Seq[FhirPathResult] = {
     val value = handleFhirQuantityValue(valueExpr)
 
@@ -221,6 +238,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param codeExpr   Expression to return the unit code
    * @return
    */
+  @FhirPathFunction(documentation = "Creates FHIR Quantity json object with given value unit and optional system and code. Ex: utl:createFhirQuantity(15.2, %ucum, 'mg')",
+    insertText = "utl:createFhirQuantity(<valueExpr>, <unitExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity")
   def createFhirQuantity(valueExpr: ExpressionContext,
                          unitExpr: ExpressionContext,
                          systemExpr: ExpressionContext,
@@ -275,6 +294,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param valueExpr Expression to return the value
    * @return
    */
+  @FhirPathFunction(documentation = "Checks if the given value is a FHIR Quantity expression e.g. 5.2, >7.1, etc.",
+    insertText = "utl:isFhirQuantityExpression()",detail = "utl", label = "utl:isFhirQuantityExpression")
   def isFhirQuantityExpression(): Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -308,6 +329,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param valueExpr FHIR Quantity expression with optional comparator
    * @return Seq of results where first element is the numeric value and second if exists is the comparator
    */
+  @FhirPathFunction(documentation = "Parses a FHIR quantity expression.",
+    insertText = "utl:parseFhirQuantityExpression(<valueExpr>)",detail = "utl", label = "utl:parseFhirQuantityExpression")
   def parseFhirQuantityExpression(valueExpr: ExpressionContext): Seq[FhirPathResult] = {
     handleFhirQuantityValue(valueExpr) match {
       case None => Nil
@@ -358,6 +381,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param toDate   Other date expression
    * @return
    */
+  @FhirPathFunction(documentation = "Retrieves the duration between given FHIR dateTimes as FHIR Duration with a suitable duration unit (either minute, day, or month). Ex: utl:getDurationAsQuantityObject(startTime, endTime)",
+    insertText = "utl:getDurationAsQuantityObject(<startTime>, <endTime>)",detail = "utl", label = "utl:getDurationAsQuantityObject")
   def getDurationAsQuantityObject(fromDate: ExpressionContext, toDate: ExpressionContext): Seq[FhirPathResult] = {
     val fdate: Option[Temporal] = new FhirPathExpressionEvaluator(context, current).visit(fromDate) match {
       case Seq(FhirPathDateTime(dt)) => Some(dt)
@@ -442,6 +467,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param splitCharExpr Expression to return split character(s)
    * @return
    */
+  @FhirPathFunction(documentation = "Splits the current string value by given split character or string. Ex: code.coding.first().code.utl:split('-')",
+    insertText = "utl:split(<splitCharExpr>)",detail = "utl", label = "utl:split")
   def split(splitCharExpr: ExpressionContext): Seq[FhirPathResult] = {
 
     val splitChar =
@@ -473,6 +500,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param stopCharExpr List of stop characters
    * @return
    */
+  @FhirPathFunction(documentation = "Takes the prefix of a string until one of the given stop character. Ex: 'VERY LOW.'.utl:takeUntil('.' | '*')",
+    insertText = "utl:takeUntil(<stopCharExpr>)",detail = "utl", label = "utl:takeUntil")
   def takeUntil(stopCharExpr: ExpressionContext): Seq[FhirPathResult] = {
     val stopChars: Set[Char] =
       (new FhirPathExpressionEvaluator(context, current)
@@ -495,6 +524,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param toExpr   End index (inclusive)
    * @return
    */
+  @FhirPathFunction(documentation = "Creates a list of numbers. Ex: utl:indices(1, 10)",
+    insertText = "utl:indices(<startnumber>, <endnumber>)",detail = "utl", label = "utl:indices")
   def indices(fromExpr: ExpressionContext, toExpr: ExpressionContext): Seq[FhirPathResult] = {
     val from = new FhirPathExpressionEvaluator(context, current).visit(fromExpr)
     if (from.length != 1 || !from.forall(_.isInstanceOf[FhirPathNumber]))
@@ -514,6 +545,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param condExpr Boolean expression to check for each item
    * @return
    */
+  @FhirPathFunction(documentation = "Returns the indices (starting from 1) in the current sequence of results where given expression returns true. Ex: Observation.code.coding.utl:indicesWhere($this.system='http://snomed.info/sct')",
+    insertText = "utl:indicesWhere(<condExpr>)",detail = "utl", label = "utl:indicesWhere")
   def indicesWhere(condExpr: ExpressionContext): Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -532,6 +565,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param separatorExp Expression to return a separator string
    * @return
    */
+  @FhirPathFunction(documentation = "Combines current string results with the given separator and return a string. Ex: code.mkString(' | ')",
+    insertText = "utl:mkString(<separatorExp>)",detail = "utl", label = "utl:mkString")
   def mkString(separatorExp: ExpressionContext): Seq[FhirPathResult] = {
     if (!current.forall(_.isInstanceOf[FhirPathString]))
       throw new FhirPathException(s"Invalid function call 'mkString' on non string value(s)!")
@@ -556,6 +591,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param fhirPathExpression FHIR Path expression in string format
    * @return
    */
+  @FhirPathFunction(documentation = "Evaluates expression. Ex: utl:evaluateExpression('1 + 1')",
+    insertText = "utl:evaluateExpression(<expression>)",detail = "utl", label = "utl:evaluateExpression")
   def evaluateExpression(fhirPathExpression: ExpressionContext): Seq[FhirPathResult] = {
     val fhirPath = new FhirPathExpressionEvaluator(context, current).visit(fhirPathExpression)
     if (fhirPath.length != 1 || !fhirPath.forall(_.isInstanceOf[FhirPathString]))
@@ -577,6 +614,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param msgExpr Message for the exception
    * @return
    */
+  @FhirPathFunction(documentation = "Throws a FHIR Path exception with the given msg.",
+    insertText = "utl:throwException(<msgExpr>)",detail = "utl", label = "utl:throwException")
   def throwException(msgExpr: ExpressionContext): Seq[FhirPathResult] = {
     val excMsg = new FhirPathExpressionEvaluator(context, current).visit(msgExpr)
     if (excMsg.length != 1 || !excMsg.head.isInstanceOf[FhirPathString])
@@ -592,6 +631,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param period Period requested to calculate; either 'years','months','weeks','days'
    * @return
    */
+  @FhirPathFunction(documentation = "Returns a period between the FHIR date time given in current and  FHIR date time given in first expression. Ex: effectivePeriod.utl:getPeriod(start, @2020-09-07T10:00:00Z, 'years')",
+    insertText = "utl:getPeriod(<fromDate>, <toDate>, <period>)",detail = "utl", label = "utl:getPeriod")
   def getPeriod(fromDate: ExpressionContext, toDate: ExpressionContext, period: ExpressionContext): Seq[FhirPathResult] = {
     val fdate: Option[Temporal] = new FhirPathExpressionEvaluator(context, current).visit(fromDate) match {
       case Seq(FhirPathDateTime(dt)) => Some(dt)
@@ -638,6 +679,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param sourcePattern Java time date pattern e.g. dd.MM.yyyy
    * @return
    */
+  @FhirPathFunction(documentation = "Converts it to a custom date string.",
+    insertText = "utl:toFhirDate(<sourcePattern>)",detail = "utl", label = "utl:toFhirDate")
   def toFhirDate(sourcePattern: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -666,6 +709,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    *
    * @return
    */
+  @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME). Ex: '2012-01-13 22:10:45'.utl:toFhirDateTime()",
+    insertText = "utl:toFhirDateTime()",detail = "utl", label = "utl:toFhirDateTime")
   def toFhirDateTime(): Seq[FhirPathResult] = {
     val patternsToTry = Seq("yyyy-MM-dd HH:mm:ss", "yyyy-MM-ddHH:mm:ss")
     _toFhirDateTime(patternsToTry)
@@ -678,6 +723,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param sourcePattern The format pattern of the date-time string to be converted.
    * @return
    */
+  @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME). Ex: '20120113.22:10:45'.utl:toFhirDateTime('yyyy-MM-ddHH:mm:ss' | 'yyyyMMdd.HH:mm:ss')",
+    insertText = "utl:toFhirDateTime(<system>)",detail = "utl", label = "utl:toFhirDateTime")
   def toFhirDateTime(sourcePattern: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -694,6 +741,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param zoneId        Java ZoneId representation e.g. Europe/Berlin
    * @return
    */
+  @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME) with the given time zone",
+    insertText = "utl:toFhirDateTime(<sourcePattern>, <zoneId>)",detail = "utl", label = "utl:toFhirDateTime")
   def toFhirDateTime(sourcePattern: ExpressionContext, zoneId: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -742,6 +791,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @param codingList Expression that evaluates to Seq[FhirPathString] in FHIR token query format [system]|[code]
    * @return
    */
+  @FhirPathFunction(documentation = "For FHIR coding elements, filters the ones that match the given coding list as FHIR code query",
+    insertText = "utl:isCodingIn(<codingListExpr>)",detail = "utl", label = "utl:isCodingIn")
   def isCodingIn(codingList: ExpressionContext): Seq[FhirPathResult] = {
     val systemAndCodes: Seq[(Option[String], Option[String])] = new FhirPathExpressionEvaluator(context, current).visit(codingList) match {
       case s: Seq[_] if s.forall(i => i.isInstanceOf[FhirPathString]) =>

--- a/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala
@@ -1,0 +1,14 @@
+package io.onfhir.path.annotation
+
+import scala.annotation.StaticAnnotation
+
+/**
+ * Custom annotation to mark a method as FhirPath function. It provides a documentation of the function which can be used
+ * by a code editor to suggest available functions to the user.
+ *
+ * @param documentation A human-readable string that represents a doc-comment.
+ * @param insertText    A string or snippet that should be inserted in a document when selecting this completion.
+ * @param detail        The library prefix to which FhirPath function belongs.
+ * @param label         The label (i.e. name) of function.
+ */
+class FhirPathFunction(val documentation: String, val insertText: String, val detail: String, val label: String) extends StaticAnnotation

--- a/onfhir-path/src/main/scala/io/onfhir/path/validation/ValidateFhirPathFunctionLibraries.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/validation/ValidateFhirPathFunctionLibraries.scala
@@ -1,0 +1,36 @@
+package io.onfhir.path.validation
+
+import io.onfhir.path.AbstractFhirPathFunctionLibrary
+import io.onfhir.path.annotation.FhirPathFunction
+import org.reflections.Reflections
+
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe._
+
+object ValidateFhirPathFunctionLibraries {
+
+  /**
+   * Validates that each FhirPath function defined in a FhirPath function library is annotated with FhirPathFunction annotation.
+   * It finds the classes which extend AbstractFhirPathFunctionLibrary (i.e. FhirPath function libraries) using reflection
+   * on the given package list and terminates with an exception if there are some functions missing this annotation.
+   * Otherwise, it terminates successfully.
+   *
+   * @param args the list of packages where FhirPath function libraries will be searched
+   * @throws Exception when a FhirPath function library has some functions missing FhirPathFunction annotation
+   * */
+  def main(args: Array[String]): Unit = {
+    args.foreach(p => {
+      val reflections = new Reflections(p)
+      // traverse the each library
+      reflections.getSubTypesOf(classOf[AbstractFhirPathFunctionLibrary]).forEach(c => {
+        if (currentMirror.classSymbol(c)
+          .toType
+          .decls // returns declared members of class
+          .filter(method => method.isMethod && method.isPublic && !method.isConstructor && !method.asTerm.isAccessor) // returns the public methods by discarding the constructor and 'val' methods
+          .exists(method => !method.annotations.exists(_.tree.tpe =:= typeOf[FhirPathFunction]))) { // throw an exception if there are some methods which does not have a FhirPathFunction annotation
+          throw new Exception(s"There are some methods which are not annotated with FhirPathFunction in the library: ${c.getName}")
+        }
+      })
+    })
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -568,6 +568,12 @@
                 <version>${specs2.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- Reflections -->
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>0.9.10</version>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>


### PR DESCRIPTION
- Implemented a custom annotation **FhirPathFunction** (https://github.com/srdc/onfhir/blob/fhir-path-functions/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala) to provide a documentation of FhirPath function.
- Annotated each FhirPath function with **FhirPathFunction**.
- Extended **AbstractFhirPathFunctionLibrary** with a new method called **getFunctionDocumentation** (https://github.com/srdc/onfhir/blob/fhir-path-functions/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala#L27) to retrieve documentation of FhirPath functions in the library.
- Modified the **pom.xml** of **onfhir-path** module (https://github.com/srdc/onfhir/blob/fhir-path-functions/onfhir-path/pom.xml#L38) to run a script to validate that each function in a FhirPath Function library is annotated with **FhirPathFunction**. If the validation fails, it throws an exception and the build fails.