### PR TITLE
Fhir path functions

### DIFF
--- a/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala
@@ -36,13 +36,24 @@ abstract class AbstractFhirPathFunctionLibrary {
         val annotationFields = method.annotations
           .find(_.tree.tpe =:= typeOf[FhirPathFunction]).head
           .tree.children.tail
-          .collect({ case Literal(Constant(s: String)) => s })
+          .collect({
+            // matches 'String' fields
+            case Literal(Constant(s: String)) => s
+            // matches 'Seq[String]' fields
+            case Apply(_: Tree, args: List[Tree]) =>
+              args.collect({
+                // matches 'String's in the sequence
+                case Literal(Constant(s: String)) => s
+              })
+          })
         // create an instance of FhirPathFunction
-        new FhirPathFunction(documentation = annotationFields.headOption.get,
-          insertText = annotationFields.lift(1).get,
-          detail = annotationFields.lift(2).get,
-          label = annotationFields.lift(3).get,
-          kind = annotationFields.lift(4).get)
+        new FhirPathFunction(documentation = annotationFields.headOption.get.toString,
+          insertText = annotationFields.lift(1).get.toString,
+          detail = annotationFields.lift(2).get.toString,
+          label = annotationFields.lift(3).get.toString,
+          kind = annotationFields.lift(4).get.toString,
+          returnType = annotationFields.lift(5).get.asInstanceOf[Seq[String]],
+          inputType = annotationFields.lift(6).get.asInstanceOf[Seq[String]])
       }).toSeq
 
   /**

--- a/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/AbstractFhirPathFunctionLibrary.scala
@@ -38,7 +38,11 @@ abstract class AbstractFhirPathFunctionLibrary {
           .tree.children.tail
           .collect({ case Literal(Constant(s: String)) => s })
         // create an instance of FhirPathFunction
-        new FhirPathFunction(annotationFields.headOption.get,annotationFields.lift(1).get,annotationFields.lift(2).get,annotationFields.lift(3).get)
+        new FhirPathFunction(documentation = annotationFields.headOption.get,
+          insertText = annotationFields.lift(1).get,
+          detail = annotationFields.lift(2).get,
+          label = annotationFields.lift(3).get,
+          kind = annotationFields.lift(4).get)
       }).toSeq
 
   /**

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathAggFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathAggFunctions.scala
@@ -16,7 +16,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns sum of the input numeric values, 0 if input list is empty. Ex: valueQuantity.value.sum()",
-    insertText = "agg:sum()",detail = "agg", label = "agg:sum", kind = "Method")
+    insertText = "agg:sum()",detail = "agg", label = "agg:sum", kind = "Method", returnType = Seq("number"), inputType = Seq("number"))
   def sum():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathNumber]))
       throw new FhirPathException(s"Invalid function call 'sum', one of the input values is not a numeric value!")
@@ -38,7 +38,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the sum of the values after executing the expression on given input values. Ex: sum(valueQuantity.value)",
-    insertText = "agg:sum(<expr>)",detail = "agg", label = "agg:sum", kind = "Function")
+    insertText = "agg:sum(<expr>)",detail = "agg", label = "agg:sum", kind = "Function", returnType = Seq("number"), inputType = Seq())
   def sum(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results = current.map(c => {
       val result = new FhirPathExpressionEvaluator(context, Seq(c)).visit(expr)
@@ -59,7 +59,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the average of given expression that returns a numeric value. Ex: avg($this.valueQuantity.value)",
-    insertText = "agg:avg(<expr>)",detail = "agg", label = "agg:avg", kind = "Function")
+    insertText = "agg:avg(<expr>)",detail = "agg", label = "agg:avg", kind = "Function", returnType = Seq("number"), inputType = Seq())
   def avg(expr:ExpressionContext):Seq[FhirPathResult] = {
     if(current.isEmpty)
       Nil
@@ -72,7 +72,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the average of the input numeric values. Ex: valueQuantity.value.avg()",
-    insertText = "agg:avg()",detail = "agg", label = "agg:avg", kind = "Method")
+    insertText = "agg:avg()",detail = "agg", label = "agg:avg", kind = "Method", returnType = Seq("number"), inputType = Seq("number"))
   def avg():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathNumber]))
       throw new FhirPathException(s"Invalid function call 'avg' on non numeric content!")
@@ -89,7 +89,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the minimum of the input comparable values. Ex: min($this.valueQuantity.value)",
-    insertText = "agg:min()",detail = "agg", label = "agg:min", kind = "Method")
+    insertText = "agg:min()",detail = "agg", label = "agg:min", kind = "Method", returnType = Seq("string","number","dateTime","time","quantity"), inputType = Seq("string","number","dateTime","time","quantity"))
   def min():Seq[FhirPathResult] = {
     if(current.exists(c => c.isInstanceOf[FhirPathComplex] || c.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException(s"Invalid function call 'min' on non comparable values!")
@@ -111,7 +111,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the minimum of given expression that returns a comparable value. Ex: min($this.valueQuantity.value)",
-    insertText = "agg:min(<expr>)",detail = "agg", label = "agg:min", kind = "Function")
+    insertText = "agg:min(<expr>)",detail = "agg", label = "agg:min", kind = "Function", returnType = Seq("string","number","dateTime","time","quantity"), inputType = Seq())
   def min(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results =
       current
@@ -136,7 +136,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the maximum of given expression that returns a comparable value. Ex: max($this.valueQuantity.value)",
-    insertText = "agg:max(<expr>)",detail = "agg", label = "agg:max", kind = "Function")
+    insertText = "agg:max(<expr>)",detail = "agg", label = "agg:max", kind = "Function", returnType = Seq("string","number","dateTime","time","quantity"), inputType = Seq())
   def max(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results = current
       .flatMap(c => {
@@ -159,7 +159,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the maximum of given input values. Ex: valueQuantity.value.max()",
-    insertText = "agg:max()",detail = "agg", label = "agg:max", kind = "Method")
+    insertText = "agg:max()",detail = "agg", label = "agg:max", kind = "Method", returnType = Seq("string","number","dateTime","time","quantity"), inputType = Seq("string","number","dateTime","time","quantity"))
   def max():Seq[FhirPathResult] = {
     if(current.exists(c => c.isInstanceOf[FhirPathComplex] || c.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException(s"Invalid function call 'max' on non comparable values!")
@@ -181,7 +181,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return                A list of special JSON Objects with field 'bucket' indicating the key for the bucket and 'agg' indicating the resulting aggregated value
    */
   @FhirPathFunction(documentation = "Groups the values based on some expression returning a key and apply the aggregation to each group. Ex: groupBy(Condition.subject.reference.substring(8),count())",
-    insertText = "agg:groupBy(<groupByExpr>,<aggregateExpr>)",detail = "agg", label = "agg:groupBy", kind = "Function")
+    insertText = "agg:groupBy(<groupByExpr>,<aggregateExpr>)",detail = "agg", label = "agg:groupBy", kind = "Function", returnType = Seq(), inputType = Seq())
   def groupBy(groupByExpr:ExpressionContext, aggregateExpr:ExpressionContext):Seq[FhirPathResult] = {
     if(!current.forall(_.isInstanceOf[FhirPathComplex]))
       throw new FhirPathException("Invalid function call 'groupBy' on current value! The data type for current value should be complex object!")

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathAggFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathAggFunctions.scala
@@ -16,7 +16,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns sum of the input numeric values, 0 if input list is empty. Ex: valueQuantity.value.sum()",
-    insertText = "agg:sum()",detail = "agg", label = "agg:sum")
+    insertText = "agg:sum()",detail = "agg", label = "agg:sum", kind = "Method")
   def sum():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathNumber]))
       throw new FhirPathException(s"Invalid function call 'sum', one of the input values is not a numeric value!")
@@ -38,7 +38,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the sum of the values after executing the expression on given input values. Ex: sum(valueQuantity.value)",
-    insertText = "agg:sum(<expr>)",detail = "agg", label = "agg:sum")
+    insertText = "agg:sum(<expr>)",detail = "agg", label = "agg:sum", kind = "Function")
   def sum(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results = current.map(c => {
       val result = new FhirPathExpressionEvaluator(context, Seq(c)).visit(expr)
@@ -59,7 +59,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the average of given expression that returns a numeric value. Ex: avg($this.valueQuantity.value)",
-    insertText = "agg:avg(<expr>)",detail = "agg", label = "agg:avg")
+    insertText = "agg:avg(<expr>)",detail = "agg", label = "agg:avg", kind = "Function")
   def avg(expr:ExpressionContext):Seq[FhirPathResult] = {
     if(current.isEmpty)
       Nil
@@ -72,7 +72,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the average of the input numeric values. Ex: valueQuantity.value.avg()",
-    insertText = "agg:avg()",detail = "agg", label = "agg:avg")
+    insertText = "agg:avg()",detail = "agg", label = "agg:avg", kind = "Method")
   def avg():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathNumber]))
       throw new FhirPathException(s"Invalid function call 'avg' on non numeric content!")
@@ -89,7 +89,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the minimum of the input comparable values. Ex: min($this.valueQuantity.value)",
-    insertText = "agg:min()",detail = "agg", label = "agg:min")
+    insertText = "agg:min()",detail = "agg", label = "agg:min", kind = "Method")
   def min():Seq[FhirPathResult] = {
     if(current.exists(c => c.isInstanceOf[FhirPathComplex] || c.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException(s"Invalid function call 'min' on non comparable values!")
@@ -111,7 +111,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the minimum of given expression that returns a comparable value. Ex: min($this.valueQuantity.value)",
-    insertText = "agg:min(<expr>)",detail = "agg", label = "agg:min")
+    insertText = "agg:min(<expr>)",detail = "agg", label = "agg:min", kind = "Function")
   def min(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results =
       current
@@ -136,7 +136,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the maximum of given expression that returns a comparable value. Ex: max($this.valueQuantity.value)",
-    insertText = "agg:max(<expr>)",detail = "agg", label = "agg:max")
+    insertText = "agg:max(<expr>)",detail = "agg", label = "agg:max", kind = "Function")
   def max(expr:ExpressionContext):Seq[FhirPathResult] = {
     val results = current
       .flatMap(c => {
@@ -159,7 +159,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "Returns the maximum of given input values. Ex: valueQuantity.value.max()",
-    insertText = "agg:max()",detail = "agg", label = "agg:max")
+    insertText = "agg:max()",detail = "agg", label = "agg:max", kind = "Method")
   def max():Seq[FhirPathResult] = {
     if(current.exists(c => c.isInstanceOf[FhirPathComplex] || c.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException(s"Invalid function call 'max' on non comparable values!")
@@ -181,7 +181,7 @@ class FhirPathAggFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return                A list of special JSON Objects with field 'bucket' indicating the key for the bucket and 'agg' indicating the resulting aggregated value
    */
   @FhirPathFunction(documentation = "Groups the values based on some expression returning a key and apply the aggregation to each group. Ex: groupBy(Condition.subject.reference.substring(8),count())",
-    insertText = "agg:groupBy(<groupByExpr>,<aggregateExpr>)",detail = "agg", label = "agg:groupBy")
+    insertText = "agg:groupBy(<groupByExpr>,<aggregateExpr>)",detail = "agg", label = "agg:groupBy", kind = "Function")
   def groupBy(groupByExpr:ExpressionContext, aggregateExpr:ExpressionContext):Seq[FhirPathResult] = {
     if(!current.forall(_.isInstanceOf[FhirPathComplex]))
       throw new FhirPathException("Invalid function call 'groupBy' on current value! The data type for current value should be complex object!")

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathFunctionEvaluator.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathFunctionEvaluator.scala
@@ -28,7 +28,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @return
     */
   @FhirPathFunction(documentation = "Calls the specified function with parameters",
-    insertText = "callFunction(<library-prefix>,<function-name>,<params>)", detail = "", label = "callFunction", kind = "Function")
+    insertText = "callFunction(<library-prefix>,<function-name>,<params>)", detail = "", label = "callFunction", kind = "Function", returnType = Seq(), inputType = Seq())
   def callFunction(fprefix:Option[String], fname:String, params:Seq[ExpressionContext]):Seq[FhirPathResult] = {
     fprefix match {
       //It is an original FHIR Path function or calling it without specificying a prefix
@@ -69,7 +69,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Resolves a reference",
-    insertText = "resolve()", detail = "", label = "resolve", kind = "Method")
+    insertText = "resolve()", detail = "", label = "resolve", kind = "Method", returnType = Seq(), inputType = Seq())
   def resolve():Seq[FhirPathResult] = {
     val fhirReferences = current.map {
       case FhirPathString(uri) => FHIRUtil.parseCanonicalReference(uri)
@@ -88,7 +88,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns a specific extension",
-    insertText = "extension(<urlExp>)", detail = "", label = "extension", kind = "Method")
+    insertText = "extension(<urlExp>)", detail = "", label = "extension", kind = "Method", returnType = Seq(), inputType = Seq())
   def extension(urlExp:ExpressionContext):Seq[FhirPathResult] = {
     val url = new FhirPathExpressionEvaluator(context, current).visit(urlExp)
     if(url.length != 1 || !url.head.isInstanceOf[FhirPathString])
@@ -105,13 +105,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Type functions, for these basic casting or type checking are done before calling the function on the left expression
     */
   @FhirPathFunction(documentation = "Returns a collection that contains all items in the input collection that are of the given type or a subclass thereof.",
-    insertText = "ofType(<expr>)", detail = "", label = "ofType", kind = "Method")
+    insertText = "ofType(<expr>)", detail = "", label = "ofType", kind = "Method", returnType = Seq(), inputType = Seq())
   def ofType(typ:ExpressionContext):Seq[FhirPathResult] = current
   @FhirPathFunction(documentation = "If the left operand is a collection with a single item and the second operand is an identifier, this operator returns the value of the left operand if it is of the type specified in the second operand, or a subclass thereof. ",
-    insertText = "as(<expr>)", detail = "", label = "as", kind = "Method")
+    insertText = "as(<expr>)", detail = "", label = "as", kind = "Method", returnType = Seq(), inputType = Seq())
   def as(typ:ExpressionContext):Seq[FhirPathResult] = current
   @FhirPathFunction(documentation = "If the left operand is a collection with a single item and the second operand is a type identifier, this operator returns true if the type of the left operand is the type specified in the second operand, or a subclass thereof. ",
-    insertText = "is(<expr>)", detail = "", label = "is", kind = "Method")
+    insertText = "is(<expr>)", detail = "", label = "is", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def is(typ:ExpressionContext):Seq[FhirPathResult] = {
     current.length match {
       case 0 => Seq(FhirPathBoolean(false))
@@ -126,11 +126,11 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @return
     */
   @FhirPathFunction(documentation = "Returns true if the input collection is empty ({ }) and false otherwise.",
-    insertText = "empty()", detail = "", label = "empty", kind = "Method")
+    insertText = "empty()", detail = "", label = "empty", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def empty():Seq[FhirPathResult] = Seq(FhirPathBoolean(current.isEmpty))
 
   @FhirPathFunction(documentation = "Returns true if the input collection evaluates to false, and false if it evaluates to true.",
-    insertText = "not()", detail = "", label = "not", kind = "Method")
+    insertText = "not()", detail = "", label = "not", kind = "Method", returnType = Seq("boolean"), inputType = Seq("boolean"))
   def not():Seq[FhirPathResult] = current match {
     case Nil => Nil
     case Seq(FhirPathBoolean(b)) => Seq(FhirPathBoolean(!b))
@@ -153,13 +153,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if the collection has any elements satisfying the criteria, and false otherwise.",
-    insertText = "exists(<expr>)", detail = "", label = "exists", kind = "Method")
+    insertText = "exists(<expr>)", detail = "", label = "exists", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def exists(expr:ExpressionContext):Seq[FhirPathResult] = exists(Some(expr))
   @FhirPathFunction(documentation = "Returns true if the collection has any elements, and false otherwise.",
-    insertText = "exists()", detail = "", label = "exists", kind = "Method")
+    insertText = "exists()", detail = "", label = "exists", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def exists():Seq[FhirPathResult] = exists(None)
   @FhirPathFunction(documentation = "Returns true if for every element in the input collection, criteria evaluates to true.",
-    insertText = "all(<criteria>)", detail = "", label = "all", kind = "Method")
+    insertText = "all(<criteria>)", detail = "", label = "all", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def all(criteria:ExpressionContext):Seq[FhirPathResult] = {
     val result =
       current
@@ -173,7 +173,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if all the items are true.",
-    insertText = "allTrue()", detail = "", label = "allTrue", kind = "Method")
+    insertText = "allTrue()", detail = "", label = "allTrue", kind = "Method", returnType = Seq("boolean"), inputType = Seq("boolean"))
   def allTrue():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'allTrue' should run on collection of FHIR Path boolean values!!!")
@@ -181,7 +181,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if any of the items are true.",
-    insertText = "anyTrue()", detail = "", label = "anyTrue", kind = "Method")
+    insertText = "anyTrue()", detail = "", label = "anyTrue", kind = "Method", returnType = Seq("boolean"), inputType = Seq("boolean"))
   def anyTrue():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'anyTrue' should run on collection of FHIR Path boolean values!!!")
@@ -189,7 +189,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if all the items are false.",
-    insertText = "allFalse()", detail = "", label = "allFalse", kind = "Method")
+    insertText = "allFalse()", detail = "", label = "allFalse", kind = "Method", returnType = Seq("boolean"), inputType = Seq("boolean"))
   def allFalse():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'allFalse' should run on collection of FHIR Path boolean values!!!")
@@ -197,7 +197,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if any of the items are false",
-    insertText = "anyFalse()", detail = "", label = "anyFalse", kind = "Method")
+    insertText = "anyFalse()", detail = "", label = "anyFalse", kind = "Method", returnType = Seq("boolean"), inputType = Seq("boolean"))
   def anyFalse():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'anyFalse' should run on collection of FHIR Path boolean values!!!")
@@ -205,14 +205,14 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if all items in the input collection are members of the collection passed as the other argument.",
-    insertText = "subsetOf(<other>)", detail = "", label = "subsetOf", kind = "Method")
+    insertText = "subsetOf(<other>)", detail = "", label = "subsetOf", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def subsetOf(other:ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     val result = current.forall(c => otherCollection.exists(o => c.isEqual(o).getOrElse(false)))
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if all items in the collection passed as the other argument are members of the input collection.",
-    insertText = "supersetOf(<other>)", detail = "", label = "supersetOf", kind = "Method")
+    insertText = "supersetOf(<other>)", detail = "", label = "supersetOf", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def supersetOf(other:ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     val result =
@@ -223,17 +223,17 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if all the items in the input collection are distinct.",
-    insertText = "isDistinct()", detail = "", label = "isDistinct", kind = "Method")
+    insertText = "isDistinct()", detail = "", label = "isDistinct", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def isDistinct():Seq[FhirPathResult] = {
     Seq(FhirPathBoolean(current.distinct.length == current.length))
   }
   @FhirPathFunction(documentation = "Returns a collection containing only the unique items in the input collection. ",
-    insertText = "distinct()", detail = "", label = "distinct", kind = "Method")
+    insertText = "distinct()", detail = "", label = "distinct", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def distinct():Seq[FhirPathResult] = {
     current.distinct
   }
   @FhirPathFunction(documentation = "Returns the integer count of the number of items in the input collection.",
-    insertText = "count()", detail = "", label = "count", kind = "Method")
+    insertText = "count()", detail = "", label = "count", kind = "Method", returnType = Seq("integer"), inputType = Seq())
   def count():Seq[FhirPathResult] = {
     Seq(FhirPathNumber(current.length))
   }
@@ -242,7 +242,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Filtering and projection http://hl7.org/fhirpath/#filtering-and-projection
     */
   @FhirPathFunction(documentation = "Returns a collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.",
-    insertText = "where(<criteria>)", detail = "", label = "where", kind = "Method")
+    insertText = "where(<criteria>)", detail = "", label = "where", kind = "Method", returnType = Seq(), inputType = Seq())
   def where(criteria : ExpressionContext):Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -258,7 +258,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   }
 
   @FhirPathFunction(documentation = "Evaluates the projection expression for each item in the input collection.",
-    insertText = "select(<projection>)", detail = "", label = "select", kind = "Method")
+    insertText = "select(<projection>)", detail = "", label = "select", kind = "Method", returnType = Seq(), inputType = Seq())
   def select(projection: ExpressionContext):Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -268,7 +268,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       })
   }
   @FhirPathFunction(documentation = "A version of select that will repeat the projection and add it to the output collection",
-    insertText = "repeat(<projection>)", detail = "", label = "repeat", kind = "Method")
+    insertText = "repeat(<projection>)", detail = "", label = "repeat", kind = "Method", returnType = Seq(), inputType = Seq())
   def repeat(projection: ExpressionContext):Seq[FhirPathResult] = {
     val firstResults = select(projection)
     if(firstResults.nonEmpty)
@@ -281,7 +281,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Subsetting http://hl7.org/fhirpath/#subsetting
     */
   @FhirPathFunction(documentation = "Returns the single item in the input if there is just one item.",
-    insertText = "single()", detail = "", label = "single", kind = "Method")
+    insertText = "single()", detail = "", label = "single", kind = "Method", returnType = Seq(), inputType = Seq())
   def single():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -290,16 +290,16 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Returns a collection containing only the first item in the input collection.",
-    insertText = "first()", detail = "", label = "first", kind = "Method")
+    insertText = "first()", detail = "", label = "first", kind = "Method", returnType = Seq(), inputType = Seq())
   def first():Seq[FhirPathResult] = current.headOption.toSeq
   @FhirPathFunction(documentation = "Returns a collection containing only the last item in the input collection. Will return an empty collection if the input collection has no items.",
-    insertText = "last()", detail = "", label = "last", kind = "Method")
+    insertText = "last()", detail = "", label = "last", kind = "Method", returnType = Seq(), inputType = Seq())
   def last():Seq[FhirPathResult] = current.lastOption.toSeq
   @FhirPathFunction(documentation = "Returns a collection containing all but the first item in the input collection.",
-    insertText = "tail()", detail = "", label = "tail", kind = "Method")
+    insertText = "tail()", detail = "", label = "tail", kind = "Method", returnType = Seq(), inputType = Seq())
   def tail():Seq[FhirPathResult] = if(current.isEmpty) Nil else current.tail
   @FhirPathFunction(documentation = "Returns a collection containing all but the first num items in the input collection. ",
-    insertText = "skip(<numExpr>)", detail = "", label = "skip", kind = "Method")
+    insertText = "skip(<numExpr>)", detail = "", label = "skip", kind = "Method", returnType = Seq(), inputType = Seq())
   def skip(numExpr:ExpressionContext):Seq[FhirPathResult] = {
     val numValue = new FhirPathExpressionEvaluator(context, current).visit(numExpr)
     if(numValue.length != 1 || !numValue.head.isInstanceOf[FhirPathNumber])
@@ -317,7 +317,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       current.drop(i)
   }
   @FhirPathFunction(documentation = "Returns a collection containing the first num items in the input collection, or less if there are less than num items. ",
-    insertText = "take(<numExpr>)", detail = "", label = "take", kind = "Method")
+    insertText = "take(<numExpr>)", detail = "", label = "take", kind = "Method", returnType = Seq(), inputType = Seq())
   def take(numExpr:ExpressionContext):Seq[FhirPathResult] = {
     val numValue = new FhirPathExpressionEvaluator(context, current).visit(numExpr)
     if(numValue.length != 1 || !numValue.head.isInstanceOf[FhirPathNumber])
@@ -331,13 +331,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       current.take(i)
   }
   @FhirPathFunction(documentation = "Returns the set of elements that are in both collections. ",
-    insertText = "intersect(<otherCollExpr>)", detail = "", label = "intersect", kind = "Method")
+    insertText = "intersect(<otherCollExpr>)", detail = "", label = "intersect", kind = "Method", returnType = Seq(), inputType = Seq())
   def intersect(otherCollExpr:ExpressionContext):Seq[FhirPathResult] = {
     val otherSet = new FhirPathExpressionEvaluator(context, current).visit(otherCollExpr)
     current.filter(c => otherSet.exists(o => c.isEqual(o).getOrElse(false))).distinct
   }
   @FhirPathFunction(documentation = "Returns the set of elements that are not in the other collection. ",
-    insertText = "exclude(<otherCollExpr>)", detail = "", label = "exclude", kind = "Method")
+    insertText = "exclude(<otherCollExpr>)", detail = "", label = "exclude", kind = "Method", returnType = Seq(), inputType = Seq())
   def exclude(otherCollExpr:ExpressionContext):Seq[FhirPathResult] = {
     val otherSet = new FhirPathExpressionEvaluator(context, current).visit(otherCollExpr)
     current.filterNot(c => otherSet.exists(o => c.isEqual(o).getOrElse(false))).distinct
@@ -350,7 +350,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the absolute value of the input.",
-    insertText = "abs()", detail = "", label = "abs", kind = "Method")
+    insertText = "abs()", detail = "", label = "abs", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def abs():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -367,7 +367,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the first integer greater than or equal to the input.",
-    insertText = "ceiling()", detail = "", label = "ceiling", kind = "Method")
+    insertText = "ceiling()", detail = "", label = "ceiling", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def ceiling():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -385,7 +385,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns e raised to the power of the input.",
-    insertText = "exp()", detail = "", label = "exp", kind = "Method")
+    insertText = "exp()", detail = "", label = "exp", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def exp():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -402,7 +402,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the first integer less than or equal to the input.",
-    insertText = "floor()", detail = "", label = "floor", kind = "Method")
+    insertText = "floor()", detail = "", label = "floor", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def floor():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -420,7 +420,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the natural logarithm of the input (i.e. the logarithm base e).",
-    insertText = "ln()", detail = "", label = "ln", kind = "Method")
+    insertText = "ln()", detail = "", label = "ln", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def ln():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -440,7 +440,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the logarithm base base of the input number.",
-    insertText = "log(<baseExp>)", detail = "", label = "log", kind = "Method")
+    insertText = "log(<baseExp>)", detail = "", label = "log", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def log(baseExp:ExpressionContext):Seq[FhirPathResult] = {
     val baseResult = new FhirPathExpressionEvaluator(context, current).visit(baseExp)
     if(baseResult.length != 1 || !baseResult.head.isInstanceOf[FhirPathNumber])
@@ -463,7 +463,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Raises a number to the exponent power.",
-    insertText = "power(<exponentExpr>)", detail = "", label = "power", kind = "Method")
+    insertText = "power(<exponentExpr>)", detail = "", label = "power", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def power(exponentExpr:ExpressionContext):Seq[FhirPathResult] = {
     val exponentResult = new FhirPathExpressionEvaluator(context, current).visit(exponentExpr)
     if(exponentResult.length != 1 || !exponentResult.head.isInstanceOf[FhirPathNumber])
@@ -484,7 +484,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Rounds the decimal to the nearest whole number using a traditional round.",
-    insertText = "round()", detail = "", label = "round", kind = "Method")
+    insertText = "round()", detail = "", label = "round", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def round():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -503,7 +503,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Rounds the decimal to the nearest whole number using a traditional round.",
-    insertText = "round(<precisionExpr>)", detail = "", label = "round", kind = "Method")
+    insertText = "round(<precisionExpr>)", detail = "", label = "round", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def round(precisionExpr:ExpressionContext):Seq[FhirPathResult] = {
     val precisionResult = new FhirPathExpressionEvaluator(context, current).visit(precisionExpr)
     precisionResult match {
@@ -528,7 +528,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the square root of the input number as a Decimal.",
-    insertText = "sqrt()", detail = "", label = "sqrt", kind = "Method")
+    insertText = "sqrt()", detail = "", label = "sqrt", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def sqrt():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -555,7 +555,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the integer portion of the input.",
-    insertText = "truncate()", detail = "", label = "truncate", kind = "Method")
+    insertText = "truncate()", detail = "", label = "truncate", kind = "Method", returnType = Seq("number","quantity"), inputType = Seq("number","quantity"))
   def truncate():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -572,7 +572,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @return
     */
   @FhirPathFunction(documentation = "Merges the input and other collections into a single collection without eliminating duplicate values.",
-    insertText = "combine(<other>)", detail = "", label = "combine", kind = "Method")
+    insertText = "combine(<other>)", detail = "", label = "combine", kind = "Method", returnType = Seq(), inputType = Seq())
   def combine(other : ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     current ++ otherCollection
@@ -582,7 +582,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Conversion functions http://hl7.org/fhirpath/#conversion
     */
   @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument. Otherwise, it returns otherwise-result",
-    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif", kind = "Function")
+    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif", kind = "Function", returnType = Seq(), inputType = Seq())
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext, otherwiseResult: Option[ExpressionContext]):Seq[FhirPathResult] = {
     val criteriaResult = new FhirPathExpressionEvaluator(context, current).visit(criterium)
     val conditionResult = criteriaResult match {
@@ -596,10 +596,10 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       otherwiseResult.map(ore =>  new FhirPathExpressionEvaluator(context, current).visit(ore)).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument. Otherwise, it returns otherwise-result",
-    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif", kind = "Function")
+    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif", kind = "Function", returnType = Seq(), inputType = Seq())
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext, otherwiseResult: ExpressionContext) :Seq[FhirPathResult]= iif(criterium, trueResult, Some(otherwiseResult))
   @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument.",
-    insertText = "iif(<criterium>,<trueResult>)", detail = "", label = "iif", kind = "Function")
+    insertText = "iif(<criterium>,<trueResult>)", detail = "", label = "iif", kind = "Function", returnType = Seq(), inputType = Seq())
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext):Seq[FhirPathResult] = iif(criterium, trueResult, None)
 
 
@@ -608,7 +608,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to an integer.",
-    insertText = "toInteger()", detail = "", label = "toInteger", kind = "Method")
+    insertText = "toInteger()", detail = "", label = "toInteger", kind = "Method", returnType = Seq("integer"), inputType = Seq("integer","string","boolean"))
   def toInteger():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -629,7 +629,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a decimal.",
-    insertText = "toDecimal()", detail = "", label = "toDecimal", kind = "Method")
+    insertText = "toDecimal()", detail = "", label = "toDecimal", kind = "Method", returnType = Seq("decimal"), inputType = Seq("dateTime","number","string","boolean"))
   def toDecimal():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -651,7 +651,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Checks if the current item can be converted to decimal",
-    insertText = "convertsToDecimal()", detail = "", label = "convertsToDecimal", kind = "Method")
+    insertText = "convertsToDecimal()", detail = "", label = "convertsToDecimal", kind = "Method", returnType = Seq("boolean"), inputType = Seq("dateTime","number","boolean","string"))
   def convertsToDecimal():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -673,7 +673,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a boolean.",
-    insertText = "toBoolean()", detail = "", label = "toBoolean", kind = "Method")
+    insertText = "toBoolean()", detail = "", label = "toBoolean", kind = "Method", returnType = Seq("boolean"), inputType = Seq("number","string","boolean"))
   def toBoolean():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -704,7 +704,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a date.",
-    insertText = "toDate()", detail = "", label = "toDate", kind = "Method")
+    insertText = "toDate()", detail = "", label = "toDate", kind = "Method", returnType = Seq("dateTime"), inputType = Seq("dateTime","string"))
   def toDate():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -725,7 +725,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a datetime.",
-    insertText = "toDateTime()", detail = "", label = "toDateTime", kind = "Method")
+    insertText = "toDateTime()", detail = "", label = "toDateTime", kind = "Method", returnType = Seq("dateTime"), inputType = Seq("dateTime","string"))
   def toDateTime():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -742,7 +742,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Converts it to a quantity.",
-    insertText = "toQuantity()", detail = "", label = "toQuantity", kind = "Method")
+    insertText = "toQuantity()", detail = "", label = "toQuantity", kind = "Method", returnType = Seq("quantity"), inputType = Seq("number","quantity","string","boolean"))
   def toQuantity():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -756,7 +756,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Converts it to a quantity.",
-    insertText = "toQuantity(<unitExpr>)", detail = "", label = "toQuantity", kind = "Method")
+    insertText = "toQuantity(<unitExpr>)", detail = "", label = "toQuantity", kind = "Method", returnType = Seq("quantity"), inputType = Seq("number","quantity","string","boolean"))
   def toQuantity(unitExpr:ExpressionContext):Seq[FhirPathResult] = {
     val unitValue = new FhirPathExpressionEvaluator(context, current).visit(unitExpr)
     if(!unitValue.forall(_.isInstanceOf[FhirPathString]))
@@ -779,7 +779,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a string",
-    insertText = "toString()", detail = "", label = "toString", kind = "Method")
+    insertText = "toString()", detail = "", label = "toString", kind = "Method", returnType = Seq("string"), inputType = Seq("number","string","dateTime","time","quantity","boolean"))
   def _toString():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -795,7 +795,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Converts a quantity to a FHIR Path Object type (JSON).",
-    insertText = "toComplex()", detail = "", label = "toComplex", kind = "Method")
+    insertText = "toComplex()", detail = "", label = "toComplex", kind = "Method", returnType = Seq(), inputType = Seq("quantity"))
   def toComplex():Seq[FhirPathResult] = {
     current match {
       case Seq(q:FhirPathQuantity) => Seq(FhirPathComplex(q.toJson.asInstanceOf[JObject]))
@@ -812,7 +812,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     if(current.length > 1 || current.headOption.exists(!_.isInstanceOf[FhirPathString]))
       throw new FhirPathException("Invalid function call on multi item collection or non-string value!")
   @FhirPathFunction(documentation = "Returns the 0-based index of the first position substring is found in the input string, or -1 if it is not found. Ex: 'abcdefg'.indexOf('bc')",
-    insertText = "indexOf(<substringExpr>)", detail = "", label = "indexOf", kind = "Method")
+    insertText = "indexOf(<substringExpr>)", detail = "", label = "indexOf", kind = "Method", returnType = Seq("integer"), inputType = Seq("string"))
   def indexOf(substringExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -823,7 +823,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3,1)",
-    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring", kind = "Method")
+    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def substring(startExpr : ExpressionContext, lengthExpr:Option[ExpressionContext]):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -849,13 +849,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3)",
-    insertText = "substring(<startExpr>)", detail = "", label = "substring", kind = "Method")
+    insertText = "substring(<startExpr>)", detail = "", label = "substring", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def substring(startExpr:ExpressionContext):Seq[FhirPathResult] = substring(startExpr, None)
   @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3,2)",
-    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring", kind = "Method")
+    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def substring(startExpr:ExpressionContext, lengthExpr:ExpressionContext):Seq[FhirPathResult] = substring(startExpr, Some(lengthExpr))
   @FhirPathFunction(documentation = "Returns true when the input string starts with the given prefix. Ex: 'abcdefg'.startsWith('abc')",
-    insertText = "startsWith(<prefixExpr>)", detail = "", label = "startsWith", kind = "Method")
+    insertText = "startsWith(<prefixExpr>)", detail = "", label = "startsWith", kind = "Method", returnType = Seq("boolean"), inputType = Seq("string"))
   def startsWith(prefixExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -869,7 +869,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns true when the input string ends with the given suffix. Ex: 'abcdefg'.endsWith('efg')",
-    insertText = "endsWith(<suffixExpr>)", detail = "", label = "endsWith", kind = "Method")
+    insertText = "endsWith(<suffixExpr>)", detail = "", label = "endsWith", kind = "Method", returnType = Seq("boolean"), inputType = Seq("string"))
   def endsWith(suffixExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -880,7 +880,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns true when the given substring is a substring of the input string. Ex: 'abc'.contains('b')",
-    insertText = "contains(<substringExpr>)", detail = "", label = "contains", kind = "Method")
+    insertText = "contains(<substringExpr>)", detail = "", label = "contains", kind = "Method", returnType = Seq("boolean"), inputType = Seq("string"))
   def _contains(substringExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -891,7 +891,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the input string with all instances of pattern replaced with substitution. Ex: 'abcdefg'.replace('cde', '123')",
-    insertText = "replace(<patternExpr>,<substitutionExpr>)", detail = "", label = "replace", kind = "Method")
+    insertText = "replace(<patternExpr>,<substitutionExpr>)", detail = "", label = "replace", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def replace(patternExpr : ExpressionContext, substitutionExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -909,7 +909,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns true when the value matches the given regular expression.",
-    insertText = "matches(<regexExpr>)", detail = "", label = "matches", kind = "Method")
+    insertText = "matches(<regexExpr>)", detail = "", label = "matches", kind = "Method", returnType = Seq("boolean"), inputType = Seq("string","dateTime","number"))
   def matches(regexExpr : ExpressionContext):Seq[FhirPathResult] = {
     current.headOption.map(c => {
       new FhirPathExpressionEvaluator(context, current).visit(regexExpr) match {
@@ -930,7 +930,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Matches the input using the regular expression in regex and replaces each match with the substitution string.",
-    insertText = "replaceMatches(<regexExpr>,<substitutionExpr>)", detail = "", label = "replaceMatches", kind = "Method")
+    insertText = "replaceMatches(<regexExpr>,<substitutionExpr>)", detail = "", label = "replaceMatches", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def replaceMatches(regexExpr : ExpressionContext, substitutionExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -948,7 +948,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the length of the input string.",
-    insertText = "length()", detail = "", label = "length", kind = "Method")
+    insertText = "length()", detail = "", label = "length", kind = "Method", returnType = Seq("integer"), inputType = Seq("string"))
   def length():Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => Seq(FhirPathNumber(c.asInstanceOf[FhirPathString].s.length))).getOrElse(Nil)
@@ -958,7 +958,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Tree navigation function http://hl7.org/fhirpath/#tree-navigation
     */
   @FhirPathFunction(documentation = "Returns a collection with all immediate child nodes of all items in the input collection. Ex: Questionnaire.children().select(item)",
-    insertText = "children()", detail = "", label = "children", kind = "Method")
+    insertText = "children()", detail = "", label = "children", kind = "Method", returnType = Seq(), inputType = Seq())
   def children():Seq[FhirPathResult] = {
     current
       .filter(_.isInstanceOf[FhirPathComplex])
@@ -966,7 +966,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       .flatMap(pc => pc.json.obj.map(_._2).flatMap(i => FhirPathValueTransformer.transform(i, context.isContentFhir)))
   }
   @FhirPathFunction(documentation = "Returns a collection with all descendant nodes of all items in the input collection. Ex: Questionnaire.descendants().select(item)",
-    insertText = "descendants()", detail = "", label = "descendants", kind = "Method")
+    insertText = "descendants()", detail = "", label = "descendants", kind = "Method", returnType = Seq(), inputType = Seq())
   def descendants():Seq[FhirPathResult] = {
     val results = children()
     if(results.nonEmpty)
@@ -976,7 +976,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   }
 
   @FhirPathFunction(documentation = "Returns true if the input collection contains values",
-    insertText = "hasValue()", detail = "", label = "hasValue", kind = "Method")
+    insertText = "hasValue()", detail = "", label = "hasValue", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def hasValue():Seq[FhirPathResult] = {
     Seq(FhirPathBoolean(current.nonEmpty))
   }
@@ -988,7 +988,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Ex: value.aggregate($this + $total, 0)",
-    insertText = "aggregate(<aggExpr>,<initValueExpr>)", detail = "", label = "aggregate", kind = "Method")
+    insertText = "aggregate(<aggExpr>,<initValueExpr>)", detail = "", label = "aggregate", kind = "Method", returnType = Seq(), inputType = Seq())
   def aggregate(aggExpr:ExpressionContext, initValueExpr:ExpressionContext):Seq[FhirPathResult] = {
     val initValue = new FhirPathExpressionEvaluator(context, current).visit(initValueExpr)
     if(initValue.length > 1)
@@ -1022,7 +1022,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Ex: value.aggregate($this + $total)",
-    insertText = "aggregate(<aggExpr>)", detail = "", label = "aggregate", kind = "Method")
+    insertText = "aggregate(<aggExpr>)", detail = "", label = "aggregate", kind = "Method", returnType = Seq(), inputType = Seq())
   def aggregate(aggExpr:ExpressionContext):Seq[FhirPathResult] = {
       handleAggregate(context, aggExpr)
   }
@@ -1031,19 +1031,19 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Utility functions http://hl7.org/fhirpath/#utility-functions
     */
   @FhirPathFunction(documentation = "Returns the current date.",
-    insertText = "today()", detail = "", label = "today", kind = "Function")
+    insertText = "today()", detail = "", label = "today", kind = "Function", returnType = Seq("dateTime"), inputType = Seq())
   def today():Seq[FhirPathResult] = Seq(FhirPathDateTime(LocalDate.now()))
   @FhirPathFunction(documentation = "Returns the current date and time, including timezone offset.",
-    insertText = "now()", detail = "", label = "now", kind = "Function")
+    insertText = "now()", detail = "", label = "now", kind = "Function", returnType = Seq("dateTime"), inputType = Seq())
   def now():Seq[FhirPathResult] = Seq(FhirPathDateTime(ZonedDateTime.now()))
   @FhirPathFunction(documentation = "Adds a String representation of the input collection to the diagnostic log, using the name argument as the name in the log. Ex: contained.where(criteria).trace('unmatched').empty()",
-    insertText = "trace(<nameExpr>)", detail = "", label = "trace", kind = "Method")
+    insertText = "trace(<nameExpr>)", detail = "", label = "trace", kind = "Method", returnType = Seq(), inputType = Seq())
   def trace(nameExpr : ExpressionContext):Seq[FhirPathResult] = {
     //TODO log the current value with the given name
     current
   }
   @FhirPathFunction(documentation = "Adds a String representation of the input collection to the diagnostic log, using the name argument as the name in the log. Ex: contained.where(criteria).trace('unmatched', id).empty()",
-    insertText = "trace(<nameExpr>,<othExpr>)", detail = "", label = "trace", kind = "Method")
+    insertText = "trace(<nameExpr>,<othExpr>)", detail = "", label = "trace", kind = "Method", returnType = Seq(), inputType = Seq())
   def trace(nameExpr : ExpressionContext, othExpr:ExpressionContext):Seq[FhirPathResult] = {
     current
   }

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathFunctionEvaluator.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathFunctionEvaluator.scala
@@ -28,7 +28,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @return
     */
   @FhirPathFunction(documentation = "Calls the specified function with parameters",
-    insertText = "callFunction(<library-prefix>,<function-name>,<params>)", detail = "", label = "callFunction")
+    insertText = "callFunction(<library-prefix>,<function-name>,<params>)", detail = "", label = "callFunction", kind = "Function")
   def callFunction(fprefix:Option[String], fname:String, params:Seq[ExpressionContext]):Seq[FhirPathResult] = {
     fprefix match {
       //It is an original FHIR Path function or calling it without specificying a prefix
@@ -69,7 +69,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Resolves a reference",
-    insertText = "resolve()", detail = "", label = "resolve")
+    insertText = "resolve()", detail = "", label = "resolve", kind = "Method")
   def resolve():Seq[FhirPathResult] = {
     val fhirReferences = current.map {
       case FhirPathString(uri) => FHIRUtil.parseCanonicalReference(uri)
@@ -88,7 +88,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns a specific extension",
-    insertText = "extension(<urlExp>)", detail = "", label = "extension")
+    insertText = "extension(<urlExp>)", detail = "", label = "extension", kind = "Method")
   def extension(urlExp:ExpressionContext):Seq[FhirPathResult] = {
     val url = new FhirPathExpressionEvaluator(context, current).visit(urlExp)
     if(url.length != 1 || !url.head.isInstanceOf[FhirPathString])
@@ -105,13 +105,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Type functions, for these basic casting or type checking are done before calling the function on the left expression
     */
   @FhirPathFunction(documentation = "Returns a collection that contains all items in the input collection that are of the given type or a subclass thereof.",
-    insertText = "ofType(<expr>)", detail = "", label = "ofType")
+    insertText = "ofType(<expr>)", detail = "", label = "ofType", kind = "Method")
   def ofType(typ:ExpressionContext):Seq[FhirPathResult] = current
   @FhirPathFunction(documentation = "If the left operand is a collection with a single item and the second operand is an identifier, this operator returns the value of the left operand if it is of the type specified in the second operand, or a subclass thereof. ",
-    insertText = "as(<expr>)", detail = "", label = "as")
+    insertText = "as(<expr>)", detail = "", label = "as", kind = "Method")
   def as(typ:ExpressionContext):Seq[FhirPathResult] = current
   @FhirPathFunction(documentation = "If the left operand is a collection with a single item and the second operand is a type identifier, this operator returns true if the type of the left operand is the type specified in the second operand, or a subclass thereof. ",
-    insertText = "is(<expr>)", detail = "", label = "is")
+    insertText = "is(<expr>)", detail = "", label = "is", kind = "Method")
   def is(typ:ExpressionContext):Seq[FhirPathResult] = {
     current.length match {
       case 0 => Seq(FhirPathBoolean(false))
@@ -126,11 +126,11 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @return
     */
   @FhirPathFunction(documentation = "Returns true if the input collection is empty ({ }) and false otherwise.",
-    insertText = "empty()", detail = "", label = "empty")
+    insertText = "empty()", detail = "", label = "empty", kind = "Method")
   def empty():Seq[FhirPathResult] = Seq(FhirPathBoolean(current.isEmpty))
 
   @FhirPathFunction(documentation = "Returns true if the input collection evaluates to false, and false if it evaluates to true.",
-    insertText = "not()", detail = "", label = "not")
+    insertText = "not()", detail = "", label = "not", kind = "Method")
   def not():Seq[FhirPathResult] = current match {
     case Nil => Nil
     case Seq(FhirPathBoolean(b)) => Seq(FhirPathBoolean(!b))
@@ -153,13 +153,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if the collection has any elements satisfying the criteria, and false otherwise.",
-    insertText = "exists(<expr>)", detail = "", label = "exists")
+    insertText = "exists(<expr>)", detail = "", label = "exists", kind = "Method")
   def exists(expr:ExpressionContext):Seq[FhirPathResult] = exists(Some(expr))
   @FhirPathFunction(documentation = "Returns true if the collection has any elements, and false otherwise.",
-    insertText = "exists()", detail = "", label = "exists")
+    insertText = "exists()", detail = "", label = "exists", kind = "Method")
   def exists():Seq[FhirPathResult] = exists(None)
   @FhirPathFunction(documentation = "Returns true if for every element in the input collection, criteria evaluates to true.",
-    insertText = "all(<criteria>)", detail = "", label = "all")
+    insertText = "all(<criteria>)", detail = "", label = "all", kind = "Method")
   def all(criteria:ExpressionContext):Seq[FhirPathResult] = {
     val result =
       current
@@ -173,7 +173,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if all the items are true.",
-    insertText = "allTrue()", detail = "", label = "allTrue")
+    insertText = "allTrue()", detail = "", label = "allTrue", kind = "Method")
   def allTrue():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'allTrue' should run on collection of FHIR Path boolean values!!!")
@@ -181,7 +181,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if any of the items are true.",
-    insertText = "anyTrue()", detail = "", label = "anyTrue")
+    insertText = "anyTrue()", detail = "", label = "anyTrue", kind = "Method")
   def anyTrue():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'anyTrue' should run on collection of FHIR Path boolean values!!!")
@@ -189,7 +189,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if all the items are false.",
-    insertText = "allFalse()", detail = "", label = "allFalse")
+    insertText = "allFalse()", detail = "", label = "allFalse", kind = "Method")
   def allFalse():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'allFalse' should run on collection of FHIR Path boolean values!!!")
@@ -197,7 +197,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Takes a collection of Boolean values and returns true if any of the items are false",
-    insertText = "anyFalse()", detail = "", label = "anyFalse")
+    insertText = "anyFalse()", detail = "", label = "anyFalse", kind = "Method")
   def anyFalse():Seq[FhirPathResult] = {
     if(current.exists(!_.isInstanceOf[FhirPathBoolean]))
       throw new FhirPathException("Function 'anyFalse' should run on collection of FHIR Path boolean values!!!")
@@ -205,14 +205,14 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if all items in the input collection are members of the collection passed as the other argument.",
-    insertText = "subsetOf(<other>)", detail = "", label = "subsetOf")
+    insertText = "subsetOf(<other>)", detail = "", label = "subsetOf", kind = "Method")
   def subsetOf(other:ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     val result = current.forall(c => otherCollection.exists(o => c.isEqual(o).getOrElse(false)))
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if all items in the collection passed as the other argument are members of the input collection.",
-    insertText = "supersetOf(<other>)", detail = "", label = "supersetOf")
+    insertText = "supersetOf(<other>)", detail = "", label = "supersetOf", kind = "Method")
   def supersetOf(other:ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     val result =
@@ -223,17 +223,17 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     Seq(FhirPathBoolean(result))
   }
   @FhirPathFunction(documentation = "Returns true if all the items in the input collection are distinct.",
-    insertText = "isDistinct()", detail = "", label = "isDistinct")
+    insertText = "isDistinct()", detail = "", label = "isDistinct", kind = "Method")
   def isDistinct():Seq[FhirPathResult] = {
     Seq(FhirPathBoolean(current.distinct.length == current.length))
   }
   @FhirPathFunction(documentation = "Returns a collection containing only the unique items in the input collection. ",
-    insertText = "distinct()", detail = "", label = "distinct")
+    insertText = "distinct()", detail = "", label = "distinct", kind = "Method")
   def distinct():Seq[FhirPathResult] = {
     current.distinct
   }
   @FhirPathFunction(documentation = "Returns the integer count of the number of items in the input collection.",
-    insertText = "count()", detail = "", label = "count")
+    insertText = "count()", detail = "", label = "count", kind = "Method")
   def count():Seq[FhirPathResult] = {
     Seq(FhirPathNumber(current.length))
   }
@@ -242,7 +242,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Filtering and projection http://hl7.org/fhirpath/#filtering-and-projection
     */
   @FhirPathFunction(documentation = "Returns a collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.",
-    insertText = "where(<criteria>)", detail = "", label = "where")
+    insertText = "where(<criteria>)", detail = "", label = "where", kind = "Method")
   def where(criteria : ExpressionContext):Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -258,7 +258,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   }
 
   @FhirPathFunction(documentation = "Evaluates the projection expression for each item in the input collection.",
-    insertText = "select(<projection>)", detail = "", label = "select")
+    insertText = "select(<projection>)", detail = "", label = "select", kind = "Method")
   def select(projection: ExpressionContext):Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -268,7 +268,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       })
   }
   @FhirPathFunction(documentation = "A version of select that will repeat the projection and add it to the output collection",
-    insertText = "repeat(<projection>)", detail = "", label = "repeat")
+    insertText = "repeat(<projection>)", detail = "", label = "repeat", kind = "Method")
   def repeat(projection: ExpressionContext):Seq[FhirPathResult] = {
     val firstResults = select(projection)
     if(firstResults.nonEmpty)
@@ -281,7 +281,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Subsetting http://hl7.org/fhirpath/#subsetting
     */
   @FhirPathFunction(documentation = "Returns the single item in the input if there is just one item.",
-    insertText = "single()", detail = "", label = "single")
+    insertText = "single()", detail = "", label = "single", kind = "Method")
   def single():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -290,16 +290,16 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Returns a collection containing only the first item in the input collection.",
-    insertText = "first()", detail = "", label = "first")
+    insertText = "first()", detail = "", label = "first", kind = "Method")
   def first():Seq[FhirPathResult] = current.headOption.toSeq
   @FhirPathFunction(documentation = "Returns a collection containing only the last item in the input collection. Will return an empty collection if the input collection has no items.",
-    insertText = "last()", detail = "", label = "last")
+    insertText = "last()", detail = "", label = "last", kind = "Method")
   def last():Seq[FhirPathResult] = current.lastOption.toSeq
   @FhirPathFunction(documentation = "Returns a collection containing all but the first item in the input collection.",
-    insertText = "tail()", detail = "", label = "tail")
+    insertText = "tail()", detail = "", label = "tail", kind = "Method")
   def tail():Seq[FhirPathResult] = if(current.isEmpty) Nil else current.tail
   @FhirPathFunction(documentation = "Returns a collection containing all but the first num items in the input collection. ",
-    insertText = "skip(<numExpr>)", detail = "", label = "skip")
+    insertText = "skip(<numExpr>)", detail = "", label = "skip", kind = "Method")
   def skip(numExpr:ExpressionContext):Seq[FhirPathResult] = {
     val numValue = new FhirPathExpressionEvaluator(context, current).visit(numExpr)
     if(numValue.length != 1 || !numValue.head.isInstanceOf[FhirPathNumber])
@@ -317,7 +317,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       current.drop(i)
   }
   @FhirPathFunction(documentation = "Returns a collection containing the first num items in the input collection, or less if there are less than num items. ",
-    insertText = "take(<numExpr>)", detail = "", label = "take")
+    insertText = "take(<numExpr>)", detail = "", label = "take", kind = "Method")
   def take(numExpr:ExpressionContext):Seq[FhirPathResult] = {
     val numValue = new FhirPathExpressionEvaluator(context, current).visit(numExpr)
     if(numValue.length != 1 || !numValue.head.isInstanceOf[FhirPathNumber])
@@ -331,13 +331,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       current.take(i)
   }
   @FhirPathFunction(documentation = "Returns the set of elements that are in both collections. ",
-    insertText = "intersect(<otherCollExpr>)", detail = "", label = "intersect")
+    insertText = "intersect(<otherCollExpr>)", detail = "", label = "intersect", kind = "Method")
   def intersect(otherCollExpr:ExpressionContext):Seq[FhirPathResult] = {
     val otherSet = new FhirPathExpressionEvaluator(context, current).visit(otherCollExpr)
     current.filter(c => otherSet.exists(o => c.isEqual(o).getOrElse(false))).distinct
   }
   @FhirPathFunction(documentation = "Returns the set of elements that are not in the other collection. ",
-    insertText = "exclude(<otherCollExpr>)", detail = "", label = "exclude")
+    insertText = "exclude(<otherCollExpr>)", detail = "", label = "exclude", kind = "Method")
   def exclude(otherCollExpr:ExpressionContext):Seq[FhirPathResult] = {
     val otherSet = new FhirPathExpressionEvaluator(context, current).visit(otherCollExpr)
     current.filterNot(c => otherSet.exists(o => c.isEqual(o).getOrElse(false))).distinct
@@ -350,7 +350,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the absolute value of the input.",
-    insertText = "abs()", detail = "", label = "abs")
+    insertText = "abs()", detail = "", label = "abs", kind = "Method")
   def abs():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -367,7 +367,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the first integer greater than or equal to the input.",
-    insertText = "ceiling()", detail = "", label = "ceiling")
+    insertText = "ceiling()", detail = "", label = "ceiling", kind = "Method")
   def ceiling():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -385,7 +385,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns e raised to the power of the input.",
-    insertText = "exp()", detail = "", label = "exp")
+    insertText = "exp()", detail = "", label = "exp", kind = "Method")
   def exp():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -402,7 +402,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the first integer less than or equal to the input.",
-    insertText = "floor()", detail = "", label = "floor")
+    insertText = "floor()", detail = "", label = "floor", kind = "Method")
   def floor():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -420,7 +420,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the natural logarithm of the input (i.e. the logarithm base e).",
-    insertText = "ln()", detail = "", label = "ln")
+    insertText = "ln()", detail = "", label = "ln", kind = "Method")
   def ln():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -440,7 +440,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the logarithm base base of the input number.",
-    insertText = "log(<baseExp>)", detail = "", label = "log")
+    insertText = "log(<baseExp>)", detail = "", label = "log", kind = "Method")
   def log(baseExp:ExpressionContext):Seq[FhirPathResult] = {
     val baseResult = new FhirPathExpressionEvaluator(context, current).visit(baseExp)
     if(baseResult.length != 1 || !baseResult.head.isInstanceOf[FhirPathNumber])
@@ -463,7 +463,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Raises a number to the exponent power.",
-    insertText = "power(<exponentExpr>)", detail = "", label = "power")
+    insertText = "power(<exponentExpr>)", detail = "", label = "power", kind = "Method")
   def power(exponentExpr:ExpressionContext):Seq[FhirPathResult] = {
     val exponentResult = new FhirPathExpressionEvaluator(context, current).visit(exponentExpr)
     if(exponentResult.length != 1 || !exponentResult.head.isInstanceOf[FhirPathNumber])
@@ -484,7 +484,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Rounds the decimal to the nearest whole number using a traditional round.",
-    insertText = "round()", detail = "", label = "round")
+    insertText = "round()", detail = "", label = "round", kind = "Method")
   def round():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -503,7 +503,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Rounds the decimal to the nearest whole number using a traditional round.",
-    insertText = "round(<precisionExpr>)", detail = "", label = "round")
+    insertText = "round(<precisionExpr>)", detail = "", label = "round", kind = "Method")
   def round(precisionExpr:ExpressionContext):Seq[FhirPathResult] = {
     val precisionResult = new FhirPathExpressionEvaluator(context, current).visit(precisionExpr)
     precisionResult match {
@@ -528,7 +528,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the square root of the input number as a Decimal.",
-    insertText = "sqrt()", detail = "", label = "sqrt")
+    insertText = "sqrt()", detail = "", label = "sqrt", kind = "Method")
   def sqrt():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -555,7 +555,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Returns the integer portion of the input.",
-    insertText = "truncate()", detail = "", label = "truncate")
+    insertText = "truncate()", detail = "", label = "truncate", kind = "Method")
   def truncate():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -572,7 +572,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * @return
     */
   @FhirPathFunction(documentation = "Merges the input and other collections into a single collection without eliminating duplicate values.",
-    insertText = "combine(<other>)", detail = "", label = "combine")
+    insertText = "combine(<other>)", detail = "", label = "combine", kind = "Method")
   def combine(other : ExpressionContext):Seq[FhirPathResult] = {
     val otherCollection = new FhirPathExpressionEvaluator(context, current).visit(other)
     current ++ otherCollection
@@ -582,7 +582,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Conversion functions http://hl7.org/fhirpath/#conversion
     */
   @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument. Otherwise, it returns otherwise-result",
-    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif")
+    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif", kind = "Function")
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext, otherwiseResult: Option[ExpressionContext]):Seq[FhirPathResult] = {
     val criteriaResult = new FhirPathExpressionEvaluator(context, current).visit(criterium)
     val conditionResult = criteriaResult match {
@@ -596,10 +596,10 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       otherwiseResult.map(ore =>  new FhirPathExpressionEvaluator(context, current).visit(ore)).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument. Otherwise, it returns otherwise-result",
-    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif")
+    insertText = "iif(<criterium>,<trueResult>,<otherwiseResult>)", detail = "", label = "iif", kind = "Function")
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext, otherwiseResult: ExpressionContext) :Seq[FhirPathResult]= iif(criterium, trueResult, Some(otherwiseResult))
   @FhirPathFunction(documentation = "If criterion is true, the function returns the value of the true-result argument.",
-    insertText = "iif(<criterium>,<trueResult>)", detail = "", label = "iif")
+    insertText = "iif(<criterium>,<trueResult>)", detail = "", label = "iif", kind = "Function")
   def iif(criterium: ExpressionContext, trueResult:ExpressionContext):Seq[FhirPathResult] = iif(criterium, trueResult, None)
 
 
@@ -608,7 +608,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to an integer.",
-    insertText = "toInteger()", detail = "", label = "toInteger")
+    insertText = "toInteger()", detail = "", label = "toInteger", kind = "Method")
   def toInteger():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -629,7 +629,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a decimal.",
-    insertText = "toDecimal()", detail = "", label = "toDecimal")
+    insertText = "toDecimal()", detail = "", label = "toDecimal", kind = "Method")
   def toDecimal():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -651,7 +651,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Checks if the current item can be converted to decimal",
-    insertText = "convertsToDecimal()", detail = "", label = "convertsToDecimal")
+    insertText = "convertsToDecimal()", detail = "", label = "convertsToDecimal", kind = "Method")
   def convertsToDecimal():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -673,7 +673,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a boolean.",
-    insertText = "toBoolean()", detail = "", label = "toBoolean")
+    insertText = "toBoolean()", detail = "", label = "toBoolean", kind = "Method")
   def toBoolean():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -704,7 +704,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a date.",
-    insertText = "toDate()", detail = "", label = "toDate")
+    insertText = "toDate()", detail = "", label = "toDate", kind = "Method")
   def toDate():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -725,7 +725,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a datetime.",
-    insertText = "toDateTime()", detail = "", label = "toDateTime")
+    insertText = "toDateTime()", detail = "", label = "toDateTime", kind = "Method")
   def toDateTime():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -742,7 +742,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Converts it to a quantity.",
-    insertText = "toQuantity()", detail = "", label = "toQuantity")
+    insertText = "toQuantity()", detail = "", label = "toQuantity", kind = "Method")
   def toQuantity():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -756,7 +756,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Converts it to a quantity.",
-    insertText = "toQuantity(<unitExpr>)", detail = "", label = "toQuantity")
+    insertText = "toQuantity(<unitExpr>)", detail = "", label = "toQuantity", kind = "Method")
   def toQuantity(unitExpr:ExpressionContext):Seq[FhirPathResult] = {
     val unitValue = new FhirPathExpressionEvaluator(context, current).visit(unitExpr)
     if(!unitValue.forall(_.isInstanceOf[FhirPathString]))
@@ -779,7 +779,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a string",
-    insertText = "toString()", detail = "", label = "toString")
+    insertText = "toString()", detail = "", label = "toString", kind = "Method")
   def _toString():Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -795,7 +795,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }
   }
   @FhirPathFunction(documentation = "Converts a quantity to a FHIR Path Object type (JSON).",
-    insertText = "toComplex()", detail = "", label = "toComplex")
+    insertText = "toComplex()", detail = "", label = "toComplex", kind = "Method")
   def toComplex():Seq[FhirPathResult] = {
     current match {
       case Seq(q:FhirPathQuantity) => Seq(FhirPathComplex(q.toJson.asInstanceOf[JObject]))
@@ -812,7 +812,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     if(current.length > 1 || current.headOption.exists(!_.isInstanceOf[FhirPathString]))
       throw new FhirPathException("Invalid function call on multi item collection or non-string value!")
   @FhirPathFunction(documentation = "Returns the 0-based index of the first position substring is found in the input string, or -1 if it is not found. Ex: 'abcdefg'.indexOf('bc')",
-    insertText = "indexOf(<substringExpr>)", detail = "", label = "indexOf")
+    insertText = "indexOf(<substringExpr>)", detail = "", label = "indexOf", kind = "Method")
   def indexOf(substringExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -823,7 +823,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3,1)",
-    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring")
+    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring", kind = "Method")
   def substring(startExpr : ExpressionContext, lengthExpr:Option[ExpressionContext]):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -849,13 +849,13 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3)",
-    insertText = "substring(<startExpr>)", detail = "", label = "substring")
+    insertText = "substring(<startExpr>)", detail = "", label = "substring", kind = "Method")
   def substring(startExpr:ExpressionContext):Seq[FhirPathResult] = substring(startExpr, None)
   @FhirPathFunction(documentation = "Returns the part of the string starting at position start (zero-based). Ex: 'abcdefg'.substring(3,2)",
-    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring")
+    insertText = "substring(<startExpr>,<lengthExpr>)", detail = "", label = "substring", kind = "Method")
   def substring(startExpr:ExpressionContext, lengthExpr:ExpressionContext):Seq[FhirPathResult] = substring(startExpr, Some(lengthExpr))
   @FhirPathFunction(documentation = "Returns true when the input string starts with the given prefix. Ex: 'abcdefg'.startsWith('abc')",
-    insertText = "startsWith(<prefixExpr>)", detail = "", label = "startsWith")
+    insertText = "startsWith(<prefixExpr>)", detail = "", label = "startsWith", kind = "Method")
   def startsWith(prefixExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -869,7 +869,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns true when the input string ends with the given suffix. Ex: 'abcdefg'.endsWith('efg')",
-    insertText = "endsWith(<suffixExpr>)", detail = "", label = "endsWith")
+    insertText = "endsWith(<suffixExpr>)", detail = "", label = "endsWith", kind = "Method")
   def endsWith(suffixExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -880,7 +880,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns true when the given substring is a substring of the input string. Ex: 'abc'.contains('b')",
-    insertText = "contains(<substringExpr>)", detail = "", label = "contains")
+    insertText = "contains(<substringExpr>)", detail = "", label = "contains", kind = "Method")
   def _contains(substringExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -891,7 +891,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the input string with all instances of pattern replaced with substitution. Ex: 'abcdefg'.replace('cde', '123')",
-    insertText = "replace(<patternExpr>,<substitutionExpr>)", detail = "", label = "replace")
+    insertText = "replace(<patternExpr>,<substitutionExpr>)", detail = "", label = "replace", kind = "Method")
   def replace(patternExpr : ExpressionContext, substitutionExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -909,7 +909,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns true when the value matches the given regular expression.",
-    insertText = "matches(<regexExpr>)", detail = "", label = "matches")
+    insertText = "matches(<regexExpr>)", detail = "", label = "matches", kind = "Method")
   def matches(regexExpr : ExpressionContext):Seq[FhirPathResult] = {
     current.headOption.map(c => {
       new FhirPathExpressionEvaluator(context, current).visit(regexExpr) match {
@@ -930,7 +930,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Matches the input using the regular expression in regex and replaces each match with the substitution string.",
-    insertText = "replaceMatches(<regexExpr>,<substitutionExpr>)", detail = "", label = "replaceMatches")
+    insertText = "replaceMatches(<regexExpr>,<substitutionExpr>)", detail = "", label = "replaceMatches", kind = "Method")
   def replaceMatches(regexExpr : ExpressionContext, substitutionExpr : ExpressionContext):Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => {
@@ -948,7 +948,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     }).getOrElse(Nil)
   }
   @FhirPathFunction(documentation = "Returns the length of the input string.",
-    insertText = "length()", detail = "", label = "length")
+    insertText = "length()", detail = "", label = "length", kind = "Method")
   def length():Seq[FhirPathResult] = {
     checkSingleString()
     current.headOption.map(c => Seq(FhirPathNumber(c.asInstanceOf[FhirPathString].s.length))).getOrElse(Nil)
@@ -958,7 +958,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Tree navigation function http://hl7.org/fhirpath/#tree-navigation
     */
   @FhirPathFunction(documentation = "Returns a collection with all immediate child nodes of all items in the input collection. Ex: Questionnaire.children().select(item)",
-    insertText = "children()", detail = "", label = "children")
+    insertText = "children()", detail = "", label = "children", kind = "Method")
   def children():Seq[FhirPathResult] = {
     current
       .filter(_.isInstanceOf[FhirPathComplex])
@@ -966,7 +966,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
       .flatMap(pc => pc.json.obj.map(_._2).flatMap(i => FhirPathValueTransformer.transform(i, context.isContentFhir)))
   }
   @FhirPathFunction(documentation = "Returns a collection with all descendant nodes of all items in the input collection. Ex: Questionnaire.descendants().select(item)",
-    insertText = "descendants()", detail = "", label = "descendants")
+    insertText = "descendants()", detail = "", label = "descendants", kind = "Method")
   def descendants():Seq[FhirPathResult] = {
     val results = children()
     if(results.nonEmpty)
@@ -976,7 +976,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
   }
 
   @FhirPathFunction(documentation = "Returns true if the input collection contains values",
-    insertText = "hasValue()", detail = "", label = "hasValue")
+    insertText = "hasValue()", detail = "", label = "hasValue", kind = "Method")
   def hasValue():Seq[FhirPathResult] = {
     Seq(FhirPathBoolean(current.nonEmpty))
   }
@@ -988,7 +988,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Ex: value.aggregate($this + $total, 0)",
-    insertText = "aggregate(<aggExpr>,<initValueExpr>)", detail = "", label = "aggregate")
+    insertText = "aggregate(<aggExpr>,<initValueExpr>)", detail = "", label = "aggregate", kind = "Method")
   def aggregate(aggExpr:ExpressionContext, initValueExpr:ExpressionContext):Seq[FhirPathResult] = {
     val initValue = new FhirPathExpressionEvaluator(context, current).visit(initValueExpr)
     if(initValue.length > 1)
@@ -1022,7 +1022,7 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
    * @return
    */
   @FhirPathFunction(documentation = "Performs general-purpose aggregation by evaluating the aggregator expression for each element of the input collection. Ex: value.aggregate($this + $total)",
-    insertText = "aggregate(<aggExpr>)", detail = "", label = "aggregate")
+    insertText = "aggregate(<aggExpr>)", detail = "", label = "aggregate", kind = "Method")
   def aggregate(aggExpr:ExpressionContext):Seq[FhirPathResult] = {
       handleAggregate(context, aggExpr)
   }
@@ -1031,19 +1031,19 @@ class FhirPathFunctionEvaluator(context:FhirPathEnvironment, current:Seq[FhirPat
     * Utility functions http://hl7.org/fhirpath/#utility-functions
     */
   @FhirPathFunction(documentation = "Returns the current date.",
-    insertText = "today()", detail = "", label = "today")
+    insertText = "today()", detail = "", label = "today", kind = "Function")
   def today():Seq[FhirPathResult] = Seq(FhirPathDateTime(LocalDate.now()))
   @FhirPathFunction(documentation = "Returns the current date and time, including timezone offset.",
-    insertText = "now()", detail = "", label = "now")
+    insertText = "now()", detail = "", label = "now", kind = "Function")
   def now():Seq[FhirPathResult] = Seq(FhirPathDateTime(ZonedDateTime.now()))
   @FhirPathFunction(documentation = "Adds a String representation of the input collection to the diagnostic log, using the name argument as the name in the log. Ex: contained.where(criteria).trace('unmatched').empty()",
-    insertText = "trace(<nameExpr>)", detail = "", label = "trace")
+    insertText = "trace(<nameExpr>)", detail = "", label = "trace", kind = "Method")
   def trace(nameExpr : ExpressionContext):Seq[FhirPathResult] = {
     //TODO log the current value with the given name
     current
   }
   @FhirPathFunction(documentation = "Adds a String representation of the input collection to the diagnostic log, using the name argument as the name in the log. Ex: contained.where(criteria).trace('unmatched', id).empty()",
-    insertText = "trace(<nameExpr>,<othExpr>)", detail = "", label = "trace")
+    insertText = "trace(<nameExpr>,<othExpr>)", detail = "", label = "trace", kind = "Method")
   def trace(nameExpr : ExpressionContext, othExpr:ExpressionContext):Seq[FhirPathResult] = {
     current
   }

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathIdentityServiceFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathIdentityServiceFunctions.scala
@@ -22,7 +22,7 @@ class FhirPathIdentityServiceFunctions(context: FhirPathEnvironment) extends Abs
    * @return Identifier for the resource e.g. Patient/455435464698
    */
   @FhirPathFunction(documentation = "Resolves the given business identifier and return the FHIR Resource identifier (together with the resource type) by using the supplied identity service. Ex: idxs:resolveIdentifier('Patient', '12345', 'urn:oid:1.2.36.146.595.217.0.1')",
-    insertText = "idxs:resolveIdentifier(<resourceTypeExpr>,<identifierValueExpr>,<identifierSystemExpr>)",detail = "idxs", label = "idxs:resolveIdentifier", kind = "Function")
+    insertText = "idxs:resolveIdentifier(<resourceTypeExpr>,<identifierValueExpr>,<identifierSystemExpr>)",detail = "idxs", label = "idxs:resolveIdentifier", kind = "Function", returnType = Seq("string"), inputType = Seq())
   def resolveIdentifier(resourceTypeExpr: ExpressionContext, identifierValueExpr: ExpressionContext, identifierSystemExpr: Option[ExpressionContext]): Seq[FhirPathResult] = {
     val identityService = checkIdentityService()
 

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathIdentityServiceFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathIdentityServiceFunctions.scala
@@ -22,7 +22,7 @@ class FhirPathIdentityServiceFunctions(context: FhirPathEnvironment) extends Abs
    * @return Identifier for the resource e.g. Patient/455435464698
    */
   @FhirPathFunction(documentation = "Resolves the given business identifier and return the FHIR Resource identifier (together with the resource type) by using the supplied identity service. Ex: idxs:resolveIdentifier('Patient', '12345', 'urn:oid:1.2.36.146.595.217.0.1')",
-    insertText = "idxs:resolveIdentifier(<resourceTypeExpr>,<identifierValueExpr>,<identifierSystemExpr>)",detail = "idxs", label = "idxs:resolveIdentifier")
+    insertText = "idxs:resolveIdentifier(<resourceTypeExpr>,<identifierValueExpr>,<identifierSystemExpr>)",detail = "idxs", label = "idxs:resolveIdentifier", kind = "Function")
   def resolveIdentifier(resourceTypeExpr: ExpressionContext, identifierValueExpr: ExpressionContext, identifierSystemExpr: Option[ExpressionContext]): Seq[FhirPathResult] = {
     val identityService = checkIdentityService()
 

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathNavFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathNavFunctions.scala
@@ -16,7 +16,7 @@ class FhirPathNavFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "If the current expression returns Nil, then evaluates the else expression from start, otherwise return current. Ex: startTime.nav:orElse(plannedTime)",
-    insertText = "nav:orElse(<expression>)",detail = "nav", label = "nav:orElse", kind = "Method")
+    insertText = "nav:orElse(<expression>)",detail = "nav", label = "nav:orElse", kind = "Method", returnType = Seq(), inputType = Seq())
   def orElse(elseExpr:ExpressionContext):Seq[FhirPathResult] = {
     current match {
       case Nil =>

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathNavFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathNavFunctions.scala
@@ -16,7 +16,7 @@ class FhirPathNavFunctions(context:FhirPathEnvironment, current:Seq[FhirPathResu
    * @return
    */
   @FhirPathFunction(documentation = "If the current expression returns Nil, then evaluates the else expression from start, otherwise return current. Ex: startTime.nav:orElse(plannedTime)",
-    insertText = "nav:orElse(<expression>)",detail = "nav", label = "nav:orElse")
+    insertText = "nav:orElse(<expression>)",detail = "nav", label = "nav:orElse", kind = "Method")
   def orElse(elseExpr:ExpressionContext):Seq[FhirPathResult] = {
     current match {
       case Nil =>

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathTerminologyServiceFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathTerminologyServiceFunctions.scala
@@ -30,7 +30,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "This calls the Terminology Service $translate operation. Ex: %terminologies.translate('http://aiccelerate.eu/fhir/ConceptMap/labResultsConceptMap', Observation.code, 'conceptMapVersion=1.0')",
-    insertText = "%terminologies.translate(<conceptMapExpr>,<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate")
+    insertText = "%terminologies.translate(<conceptMapExpr>,<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate", kind = "Function")
   def translate(conceptMapExpr:ExpressionContext, codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     //Evaluate concept map url
@@ -90,7 +90,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "This calls the Terminology Service $translate operation without a concept map. Ex: %terminologies.translate(Observation.code, 'source=http://hus.fi/ValueSet/labResultCodes'&target=http://aiccelerate.eu/ValueSet/labResultCodes)",
-    insertText = "%terminologies.translate(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate")
+    insertText = "%terminologies.translate(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate", kind = "Function")
   def translate(codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     // Evaluate code
@@ -149,7 +149,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "This calls the Terminology Service $lookup operation. Ex: %terminologies.lookup(Observation.code.coding[0], 'displayLanguage=tr')",
-    insertText = "%terminologies.lookup(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.lookup")
+    insertText = "%terminologies.lookup(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.lookup", kind = "Function")
   def lookup(codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     // Evaluate code
@@ -214,7 +214,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "Returns the display string in preferred language for the given code+system. Ex:trms:lookupDisplay('C12', 'http://hus.fi/CodeSystem/labResults', 'tr')",
-    insertText = "trms.lookupDisplay(<codeExpr>,<systemExpr>,<displayLanguageExpr>)",detail = "trms", label = "trms.lookupDisplay")
+    insertText = "trms.lookupDisplay(<codeExpr>,<systemExpr>,<displayLanguageExpr>)",detail = "trms", label = "trms.lookupDisplay", kind = "Function")
   def lookupDisplay(codeExpr:ExpressionContext, systemExpr:ExpressionContext, displayLanguageExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val code = evaluateToSingleString(codeExpr)
@@ -246,7 +246,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "Translates the given Coding or CodeableConcept according to the given conceptMap. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://www.ncbi.nlm.nih.gov/clinvar')",
-    insertText = "trms.translateToCoding(<codingExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding")
+    insertText = "trms.translateToCoding(<codingExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function")
   def translateToCoding(codingExpr:ExpressionContext, conceptMapUrlExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val codingResult = evaluateCodeExpr(codingExpr)
@@ -273,7 +273,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return                  Matching codes (in Coding data type)
    */
   @FhirPathFunction(documentation = "Translates the given code+system according to the given conceptMap. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://system', 'https://www.ncbi.nlm.nih.gov/clinvar')",
-    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding")
+    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function")
   def translateToCoding(codeExpr:ExpressionContext, systemExpr:ExpressionContext, conceptMapUrlExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val conceptMapUrl = evaluateToSingleString(conceptMapUrlExpr)
@@ -300,7 +300,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "Translates the given code+system according to the given source value set and optional target value set. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://system','https://sourceValue','https://targetValue')",
-    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<sourceValueSetUrlExpr>,<targetValueSetUrlExpr>)",detail = "trms", label = "trms.translateToCoding")
+    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<sourceValueSetUrlExpr>,<targetValueSetUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function")
   def translateToCoding( codeExpr:ExpressionContext,
                          systemExpr:ExpressionContext,
                          sourceValueSetUrlExpr:ExpressionContext,

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathTerminologyServiceFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathTerminologyServiceFunctions.scala
@@ -30,7 +30,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "This calls the Terminology Service $translate operation. Ex: %terminologies.translate('http://aiccelerate.eu/fhir/ConceptMap/labResultsConceptMap', Observation.code, 'conceptMapVersion=1.0')",
-    insertText = "%terminologies.translate(<conceptMapExpr>,<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate", kind = "Function")
+    insertText = "%terminologies.translate(<conceptMapExpr>,<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate", kind = "Function", returnType = Seq(), inputType = Seq())
   def translate(conceptMapExpr:ExpressionContext, codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     //Evaluate concept map url
@@ -90,7 +90,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "This calls the Terminology Service $translate operation without a concept map. Ex: %terminologies.translate(Observation.code, 'source=http://hus.fi/ValueSet/labResultCodes'&target=http://aiccelerate.eu/ValueSet/labResultCodes)",
-    insertText = "%terminologies.translate(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate", kind = "Function")
+    insertText = "%terminologies.translate(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.translate", kind = "Function", returnType = Seq(), inputType = Seq())
   def translate(codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     // Evaluate code
@@ -149,7 +149,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "This calls the Terminology Service $lookup operation. Ex: %terminologies.lookup(Observation.code.coding[0], 'displayLanguage=tr')",
-    insertText = "%terminologies.lookup(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.lookup", kind = "Function")
+    insertText = "%terminologies.lookup(<codeExpr>,<paramsExpr>)",detail = "trms", label = "%terminologies.lookup", kind = "Function", returnType = Seq(), inputType = Seq())
   def lookup(codeExpr:ExpressionContext, paramsExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     // Evaluate code
@@ -214,7 +214,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "Returns the display string in preferred language for the given code+system. Ex:trms:lookupDisplay('C12', 'http://hus.fi/CodeSystem/labResults', 'tr')",
-    insertText = "trms.lookupDisplay(<codeExpr>,<systemExpr>,<displayLanguageExpr>)",detail = "trms", label = "trms.lookupDisplay", kind = "Function")
+    insertText = "trms.lookupDisplay(<codeExpr>,<systemExpr>,<displayLanguageExpr>)",detail = "trms", label = "trms.lookupDisplay", kind = "Function", returnType = Seq("string"), inputType = Seq())
   def lookupDisplay(codeExpr:ExpressionContext, systemExpr:ExpressionContext, displayLanguageExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val code = evaluateToSingleString(codeExpr)
@@ -246,7 +246,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "Translates the given Coding or CodeableConcept according to the given conceptMap. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://www.ncbi.nlm.nih.gov/clinvar')",
-    insertText = "trms.translateToCoding(<codingExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function")
+    insertText = "trms.translateToCoding(<codingExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function", returnType = Seq(), inputType = Seq())
   def translateToCoding(codingExpr:ExpressionContext, conceptMapUrlExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val codingResult = evaluateCodeExpr(codingExpr)
@@ -273,7 +273,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return                  Matching codes (in Coding data type)
    */
   @FhirPathFunction(documentation = "Translates the given code+system according to the given conceptMap. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://system', 'https://www.ncbi.nlm.nih.gov/clinvar')",
-    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function")
+    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<conceptMapUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function", returnType = Seq(), inputType = Seq())
   def translateToCoding(codeExpr:ExpressionContext, systemExpr:ExpressionContext, conceptMapUrlExpr:ExpressionContext):Seq[FhirPathResult] = {
     val terminologyService = checkTerminologyService()
     val conceptMapUrl = evaluateToSingleString(conceptMapUrlExpr)
@@ -300,7 +300,7 @@ class FhirPathTerminologyServiceFunctions(context:FhirPathEnvironment) extends A
    * @return
    */
   @FhirPathFunction(documentation = "Translates the given code+system according to the given source value set and optional target value set. Ex:trms:translateToCoding(Observation.code.coding.where(system='http://loinc.org').first(), 'https://system','https://sourceValue','https://targetValue')",
-    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<sourceValueSetUrlExpr>,<targetValueSetUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function")
+    insertText = "trms.translateToCoding(<codingExpr>,<systemExpr>,<sourceValueSetUrlExpr>,<targetValueSetUrlExpr>)",detail = "trms", label = "trms.translateToCoding", kind = "Function", returnType = Seq(), inputType = Seq())
   def translateToCoding( codeExpr:ExpressionContext,
                          systemExpr:ExpressionContext,
                          sourceValueSetUrlExpr:ExpressionContext,

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathUtilFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathUtilFunctions.scala
@@ -26,7 +26,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Generates an UUID",
-    insertText = "utl:uuid()",detail = "utl", label = "utl:uuid")
+    insertText = "utl:uuid()",detail = "utl", label = "utl:uuid", kind = "Function")
   def uuid(): Seq[FhirPathResult] = {
     Seq(FhirPathString(UUID.randomUUID().toString))
   }
@@ -37,7 +37,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Checks whether the given string or character starts with or is a letter.",
-    insertText = "utl:isLetter()",detail = "utl", label = "utl:isLetter")
+    insertText = "utl:isLetter()",detail = "utl", label = "utl:isLetter", kind = "Method")
   def isLetter(): Seq[FhirPathResult] = {
     current match {
       case Seq(FhirPathString(l)) => Seq(FhirPathBoolean(l.head.isLetter))
@@ -54,7 +54,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Trims the strings in the current set. Ex: ' ali  '.trim()",
-    insertText = "utl:trim()",detail = "utl", label = "utl:trim")
+    insertText = "utl:trim()",detail = "utl", label = "utl:trim", kind = "Method")
   def trim(): Seq[FhirPathResult] = {
     current.flatMap {
       case FhirPathString(s) =>
@@ -76,7 +76,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR Reference object(s) with given resource type and id(s). Ex: utl:createFhirReference('Observation', id)",
-    insertText = "utl:createFhirReference(<resourceTypeExp>, <ridExp>)",detail = "utl", label = "utl:createFhirReference")
+    insertText = "utl:createFhirReference(<resourceTypeExp>, <ridExp>)",detail = "utl", label = "utl:createFhirReference", kind = "Function")
   def createFhirReference(resourceTypeExp: ExpressionContext, ridExp: ExpressionContext): Seq[FhirPathResult] = {
     val rids = new FhirPathExpressionEvaluator(context, current).visit(ridExp)
     if (!rids.forall(_.isInstanceOf[FhirPathString]))
@@ -104,7 +104,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates a FHIR Coding content with given system code and optional display. Ex: utl:createFhirCoding('http://snomed.info/sct', '246103008', 'Certainty')",
-    insertText = "utl:createFhirCoding(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCoding")
+    insertText = "utl:createFhirCoding(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCoding", kind = "Function")
   def createFhirCoding(systemExp: ExpressionContext, codeExpr: ExpressionContext, displayExpr: ExpressionContext): Seq[FhirPathResult] = {
     val system = new FhirPathExpressionEvaluator(context, current).visit(systemExp)
     if (system.length > 1 || !system.forall(_.isInstanceOf[FhirPathString]))
@@ -142,7 +142,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR codeable concept. Ex: utl:createFhirCodeableConcept('http://snomed.info/sct', '246103008', 'Certainty')",
-    insertText = "utl:createFhirCodeableConcept(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCodeableConcept")
+    insertText = "utl:createFhirCodeableConcept(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCodeableConcept", kind = "Function")
   def createFhirCodeableConcept(systemExp: ExpressionContext, codeExpr: ExpressionContext, displayExpr: ExpressionContext): Seq[FhirPathResult] = {
     val system = new FhirPathExpressionEvaluator(context, current).visit(systemExp)
     if (system.length > 1 || !system.forall(_.isInstanceOf[FhirPathString]))
@@ -187,7 +187,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR quantity. Ex: utl:createFhirQuantity(1, 'mg')",
-    insertText = "utl:createFhirQuantity(<value>, <unit>)",detail = "utl", label = "utl:createFhirQuantity")
+    insertText = "utl:createFhirQuantity(<value>, <unit>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function")
   def createFhirQuantity(valueExpr: ExpressionContext, unitExpr: ExpressionContext): Seq[FhirPathResult] = {
     val value = handleFhirQuantityValue(valueExpr)
     val unit = new FhirPathExpressionEvaluator(context, current).visit(unitExpr)
@@ -210,7 +210,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR Quantity json object with given value, system and unit. Ex: utl:createFhirQuantity(15.2, %ucum, 'mg')",
-    insertText = "utl:createFhirQuantity(<valueExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity")
+    insertText = "utl:createFhirQuantity(<valueExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function")
   def createFhirQuantity(valueExpr: ExpressionContext, systemExpr: ExpressionContext, codeExpr: ExpressionContext): Seq[FhirPathResult] = {
     val value = handleFhirQuantityValue(valueExpr)
 
@@ -239,7 +239,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR Quantity json object with given value unit and optional system and code. Ex: utl:createFhirQuantity(15.2, %ucum, 'mg')",
-    insertText = "utl:createFhirQuantity(<valueExpr>, <unitExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity")
+    insertText = "utl:createFhirQuantity(<valueExpr>, <unitExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function")
   def createFhirQuantity(valueExpr: ExpressionContext,
                          unitExpr: ExpressionContext,
                          systemExpr: ExpressionContext,
@@ -295,7 +295,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Checks if the given value is a FHIR Quantity expression e.g. 5.2, >7.1, etc.",
-    insertText = "utl:isFhirQuantityExpression()",detail = "utl", label = "utl:isFhirQuantityExpression")
+    insertText = "utl:isFhirQuantityExpression()",detail = "utl", label = "utl:isFhirQuantityExpression", kind = "Method")
   def isFhirQuantityExpression(): Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -330,7 +330,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return Seq of results where first element is the numeric value and second if exists is the comparator
    */
   @FhirPathFunction(documentation = "Parses a FHIR quantity expression.",
-    insertText = "utl:parseFhirQuantityExpression(<valueExpr>)",detail = "utl", label = "utl:parseFhirQuantityExpression")
+    insertText = "utl:parseFhirQuantityExpression(<valueExpr>)",detail = "utl", label = "utl:parseFhirQuantityExpression", kind = "Function")
   def parseFhirQuantityExpression(valueExpr: ExpressionContext): Seq[FhirPathResult] = {
     handleFhirQuantityValue(valueExpr) match {
       case None => Nil
@@ -382,7 +382,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Retrieves the duration between given FHIR dateTimes as FHIR Duration with a suitable duration unit (either minute, day, or month). Ex: utl:getDurationAsQuantityObject(startTime, endTime)",
-    insertText = "utl:getDurationAsQuantityObject(<startTime>, <endTime>)",detail = "utl", label = "utl:getDurationAsQuantityObject")
+    insertText = "utl:getDurationAsQuantityObject(<startTime>, <endTime>)",detail = "utl", label = "utl:getDurationAsQuantityObject", kind = "Function")
   def getDurationAsQuantityObject(fromDate: ExpressionContext, toDate: ExpressionContext): Seq[FhirPathResult] = {
     val fdate: Option[Temporal] = new FhirPathExpressionEvaluator(context, current).visit(fromDate) match {
       case Seq(FhirPathDateTime(dt)) => Some(dt)
@@ -468,7 +468,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Splits the current string value by given split character or string. Ex: code.coding.first().code.utl:split('-')",
-    insertText = "utl:split(<splitCharExpr>)",detail = "utl", label = "utl:split")
+    insertText = "utl:split(<splitCharExpr>)",detail = "utl", label = "utl:split", kind = "Method")
   def split(splitCharExpr: ExpressionContext): Seq[FhirPathResult] = {
 
     val splitChar =
@@ -501,7 +501,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Takes the prefix of a string until one of the given stop character. Ex: 'VERY LOW.'.utl:takeUntil('.' | '*')",
-    insertText = "utl:takeUntil(<stopCharExpr>)",detail = "utl", label = "utl:takeUntil")
+    insertText = "utl:takeUntil(<stopCharExpr>)",detail = "utl", label = "utl:takeUntil", kind = "Method")
   def takeUntil(stopCharExpr: ExpressionContext): Seq[FhirPathResult] = {
     val stopChars: Set[Char] =
       (new FhirPathExpressionEvaluator(context, current)
@@ -525,7 +525,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates a list of numbers. Ex: utl:indices(1, 10)",
-    insertText = "utl:indices(<startnumber>, <endnumber>)",detail = "utl", label = "utl:indices")
+    insertText = "utl:indices(<startnumber>, <endnumber>)",detail = "utl", label = "utl:indices", kind = "Function")
   def indices(fromExpr: ExpressionContext, toExpr: ExpressionContext): Seq[FhirPathResult] = {
     val from = new FhirPathExpressionEvaluator(context, current).visit(fromExpr)
     if (from.length != 1 || !from.forall(_.isInstanceOf[FhirPathNumber]))
@@ -546,7 +546,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Returns the indices (starting from 1) in the current sequence of results where given expression returns true. Ex: Observation.code.coding.utl:indicesWhere($this.system='http://snomed.info/sct')",
-    insertText = "utl:indicesWhere(<condExpr>)",detail = "utl", label = "utl:indicesWhere")
+    insertText = "utl:indicesWhere(<condExpr>)",detail = "utl", label = "utl:indicesWhere", kind = "Method")
   def indicesWhere(condExpr: ExpressionContext): Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -566,7 +566,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Combines current string results with the given separator and return a string. Ex: code.mkString(' | ')",
-    insertText = "utl:mkString(<separatorExp>)",detail = "utl", label = "utl:mkString")
+    insertText = "utl:mkString(<separatorExp>)",detail = "utl", label = "utl:mkString", kind = "Method")
   def mkString(separatorExp: ExpressionContext): Seq[FhirPathResult] = {
     if (!current.forall(_.isInstanceOf[FhirPathString]))
       throw new FhirPathException(s"Invalid function call 'mkString' on non string value(s)!")
@@ -592,7 +592,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Evaluates expression. Ex: utl:evaluateExpression('1 + 1')",
-    insertText = "utl:evaluateExpression(<expression>)",detail = "utl", label = "utl:evaluateExpression")
+    insertText = "utl:evaluateExpression(<expression>)",detail = "utl", label = "utl:evaluateExpression", kind = "Function")
   def evaluateExpression(fhirPathExpression: ExpressionContext): Seq[FhirPathResult] = {
     val fhirPath = new FhirPathExpressionEvaluator(context, current).visit(fhirPathExpression)
     if (fhirPath.length != 1 || !fhirPath.forall(_.isInstanceOf[FhirPathString]))
@@ -615,7 +615,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Throws a FHIR Path exception with the given msg.",
-    insertText = "utl:throwException(<msgExpr>)",detail = "utl", label = "utl:throwException")
+    insertText = "utl:throwException(<msgExpr>)",detail = "utl", label = "utl:throwException", kind = "Function")
   def throwException(msgExpr: ExpressionContext): Seq[FhirPathResult] = {
     val excMsg = new FhirPathExpressionEvaluator(context, current).visit(msgExpr)
     if (excMsg.length != 1 || !excMsg.head.isInstanceOf[FhirPathString])
@@ -632,7 +632,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Returns a period between the FHIR date time given in current and  FHIR date time given in first expression. Ex: effectivePeriod.utl:getPeriod(start, @2020-09-07T10:00:00Z, 'years')",
-    insertText = "utl:getPeriod(<fromDate>, <toDate>, <period>)",detail = "utl", label = "utl:getPeriod")
+    insertText = "utl:getPeriod(<fromDate>, <toDate>, <period>)",detail = "utl", label = "utl:getPeriod", kind = "Method")
   def getPeriod(fromDate: ExpressionContext, toDate: ExpressionContext, period: ExpressionContext): Seq[FhirPathResult] = {
     val fdate: Option[Temporal] = new FhirPathExpressionEvaluator(context, current).visit(fromDate) match {
       case Seq(FhirPathDateTime(dt)) => Some(dt)
@@ -680,7 +680,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a custom date string.",
-    insertText = "utl:toFhirDate(<sourcePattern>)",detail = "utl", label = "utl:toFhirDate")
+    insertText = "utl:toFhirDate(<sourcePattern>)",detail = "utl", label = "utl:toFhirDate", kind = "Method")
   def toFhirDate(sourcePattern: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -710,7 +710,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME). Ex: '2012-01-13 22:10:45'.utl:toFhirDateTime()",
-    insertText = "utl:toFhirDateTime()",detail = "utl", label = "utl:toFhirDateTime")
+    insertText = "utl:toFhirDateTime()",detail = "utl", label = "utl:toFhirDateTime", kind = "Method")
   def toFhirDateTime(): Seq[FhirPathResult] = {
     val patternsToTry = Seq("yyyy-MM-dd HH:mm:ss", "yyyy-MM-ddHH:mm:ss")
     _toFhirDateTime(patternsToTry)
@@ -724,7 +724,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME). Ex: '20120113.22:10:45'.utl:toFhirDateTime('yyyy-MM-ddHH:mm:ss' | 'yyyyMMdd.HH:mm:ss')",
-    insertText = "utl:toFhirDateTime(<system>)",detail = "utl", label = "utl:toFhirDateTime")
+    insertText = "utl:toFhirDateTime(<system>)",detail = "utl", label = "utl:toFhirDateTime", kind = "Method")
   def toFhirDateTime(sourcePattern: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -742,7 +742,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME) with the given time zone",
-    insertText = "utl:toFhirDateTime(<sourcePattern>, <zoneId>)",detail = "utl", label = "utl:toFhirDateTime")
+    insertText = "utl:toFhirDateTime(<sourcePattern>, <zoneId>)",detail = "utl", label = "utl:toFhirDateTime", kind = "Method")
   def toFhirDateTime(sourcePattern: ExpressionContext, zoneId: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -792,7 +792,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "For FHIR coding elements, filters the ones that match the given coding list as FHIR code query",
-    insertText = "utl:isCodingIn(<codingListExpr>)",detail = "utl", label = "utl:isCodingIn")
+    insertText = "utl:isCodingIn(<codingListExpr>)",detail = "utl", label = "utl:isCodingIn", kind = "Method")
   def isCodingIn(codingList: ExpressionContext): Seq[FhirPathResult] = {
     val systemAndCodes: Seq[(Option[String], Option[String])] = new FhirPathExpressionEvaluator(context, current).visit(codingList) match {
       case s: Seq[_] if s.forall(i => i.isInstanceOf[FhirPathString]) =>

--- a/onfhir-path/src/main/scala/io/onfhir/path/FhirPathUtilFunctions.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/FhirPathUtilFunctions.scala
@@ -26,7 +26,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Generates an UUID",
-    insertText = "utl:uuid()",detail = "utl", label = "utl:uuid", kind = "Function")
+    insertText = "utl:uuid()",detail = "utl", label = "utl:uuid", kind = "Function", returnType = Seq("string"), inputType = Seq())
   def uuid(): Seq[FhirPathResult] = {
     Seq(FhirPathString(UUID.randomUUID().toString))
   }
@@ -37,7 +37,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Checks whether the given string or character starts with or is a letter.",
-    insertText = "utl:isLetter()",detail = "utl", label = "utl:isLetter", kind = "Method")
+    insertText = "utl:isLetter()",detail = "utl", label = "utl:isLetter", kind = "Method", returnType = Seq("boolean"), inputType = Seq("string"))
   def isLetter(): Seq[FhirPathResult] = {
     current match {
       case Seq(FhirPathString(l)) => Seq(FhirPathBoolean(l.head.isLetter))
@@ -54,7 +54,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Trims the strings in the current set. Ex: ' ali  '.trim()",
-    insertText = "utl:trim()",detail = "utl", label = "utl:trim", kind = "Method")
+    insertText = "utl:trim()",detail = "utl", label = "utl:trim", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def trim(): Seq[FhirPathResult] = {
     current.flatMap {
       case FhirPathString(s) =>
@@ -76,7 +76,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR Reference object(s) with given resource type and id(s). Ex: utl:createFhirReference('Observation', id)",
-    insertText = "utl:createFhirReference(<resourceTypeExp>, <ridExp>)",detail = "utl", label = "utl:createFhirReference", kind = "Function")
+    insertText = "utl:createFhirReference(<resourceTypeExp>, <ridExp>)",detail = "utl", label = "utl:createFhirReference", kind = "Function", returnType = Seq(), inputType = Seq())
   def createFhirReference(resourceTypeExp: ExpressionContext, ridExp: ExpressionContext): Seq[FhirPathResult] = {
     val rids = new FhirPathExpressionEvaluator(context, current).visit(ridExp)
     if (!rids.forall(_.isInstanceOf[FhirPathString]))
@@ -104,7 +104,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates a FHIR Coding content with given system code and optional display. Ex: utl:createFhirCoding('http://snomed.info/sct', '246103008', 'Certainty')",
-    insertText = "utl:createFhirCoding(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCoding", kind = "Function")
+    insertText = "utl:createFhirCoding(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCoding", kind = "Function", returnType = Seq(), inputType = Seq())
   def createFhirCoding(systemExp: ExpressionContext, codeExpr: ExpressionContext, displayExpr: ExpressionContext): Seq[FhirPathResult] = {
     val system = new FhirPathExpressionEvaluator(context, current).visit(systemExp)
     if (system.length > 1 || !system.forall(_.isInstanceOf[FhirPathString]))
@@ -142,7 +142,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR codeable concept. Ex: utl:createFhirCodeableConcept('http://snomed.info/sct', '246103008', 'Certainty')",
-    insertText = "utl:createFhirCodeableConcept(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCodeableConcept", kind = "Function")
+    insertText = "utl:createFhirCodeableConcept(<system>, <code>, <display>)",detail = "utl", label = "utl:createFhirCodeableConcept", kind = "Function", returnType = Seq(), inputType = Seq())
   def createFhirCodeableConcept(systemExp: ExpressionContext, codeExpr: ExpressionContext, displayExpr: ExpressionContext): Seq[FhirPathResult] = {
     val system = new FhirPathExpressionEvaluator(context, current).visit(systemExp)
     if (system.length > 1 || !system.forall(_.isInstanceOf[FhirPathString]))
@@ -187,7 +187,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR quantity. Ex: utl:createFhirQuantity(1, 'mg')",
-    insertText = "utl:createFhirQuantity(<value>, <unit>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function")
+    insertText = "utl:createFhirQuantity(<value>, <unit>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function", returnType = Seq(), inputType = Seq())
   def createFhirQuantity(valueExpr: ExpressionContext, unitExpr: ExpressionContext): Seq[FhirPathResult] = {
     val value = handleFhirQuantityValue(valueExpr)
     val unit = new FhirPathExpressionEvaluator(context, current).visit(unitExpr)
@@ -210,7 +210,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR Quantity json object with given value, system and unit. Ex: utl:createFhirQuantity(15.2, %ucum, 'mg')",
-    insertText = "utl:createFhirQuantity(<valueExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function")
+    insertText = "utl:createFhirQuantity(<valueExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function", returnType = Seq(), inputType = Seq())
   def createFhirQuantity(valueExpr: ExpressionContext, systemExpr: ExpressionContext, codeExpr: ExpressionContext): Seq[FhirPathResult] = {
     val value = handleFhirQuantityValue(valueExpr)
 
@@ -239,7 +239,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates FHIR Quantity json object with given value unit and optional system and code. Ex: utl:createFhirQuantity(15.2, %ucum, 'mg')",
-    insertText = "utl:createFhirQuantity(<valueExpr>, <unitExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function")
+    insertText = "utl:createFhirQuantity(<valueExpr>, <unitExpr>, <systemExpr>, <codeExpr>)",detail = "utl", label = "utl:createFhirQuantity", kind = "Function", returnType = Seq(), inputType = Seq())
   def createFhirQuantity(valueExpr: ExpressionContext,
                          unitExpr: ExpressionContext,
                          systemExpr: ExpressionContext,
@@ -295,7 +295,8 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Checks if the given value is a FHIR Quantity expression e.g. 5.2, >7.1, etc.",
-    insertText = "utl:isFhirQuantityExpression()",detail = "utl", label = "utl:isFhirQuantityExpression", kind = "Method")
+    insertText = "utl:isFhirQuantityExpression()",detail = "utl", label = "utl:isFhirQuantityExpression", kind = "Method", returnType = Seq("boolean")
+    , inputType = Seq("dateTime","number","string"))
   def isFhirQuantityExpression(): Seq[FhirPathResult] = {
     current match {
       case Nil => Nil
@@ -330,7 +331,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return Seq of results where first element is the numeric value and second if exists is the comparator
    */
   @FhirPathFunction(documentation = "Parses a FHIR quantity expression.",
-    insertText = "utl:parseFhirQuantityExpression(<valueExpr>)",detail = "utl", label = "utl:parseFhirQuantityExpression", kind = "Function")
+    insertText = "utl:parseFhirQuantityExpression(<valueExpr>)",detail = "utl", label = "utl:parseFhirQuantityExpression", kind = "Function", returnType = Seq(), inputType = Seq())
   def parseFhirQuantityExpression(valueExpr: ExpressionContext): Seq[FhirPathResult] = {
     handleFhirQuantityValue(valueExpr) match {
       case None => Nil
@@ -382,7 +383,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Retrieves the duration between given FHIR dateTimes as FHIR Duration with a suitable duration unit (either minute, day, or month). Ex: utl:getDurationAsQuantityObject(startTime, endTime)",
-    insertText = "utl:getDurationAsQuantityObject(<startTime>, <endTime>)",detail = "utl", label = "utl:getDurationAsQuantityObject", kind = "Function")
+    insertText = "utl:getDurationAsQuantityObject(<startTime>, <endTime>)",detail = "utl", label = "utl:getDurationAsQuantityObject", kind = "Function", returnType = Seq(), inputType = Seq())
   def getDurationAsQuantityObject(fromDate: ExpressionContext, toDate: ExpressionContext): Seq[FhirPathResult] = {
     val fdate: Option[Temporal] = new FhirPathExpressionEvaluator(context, current).visit(fromDate) match {
       case Seq(FhirPathDateTime(dt)) => Some(dt)
@@ -468,7 +469,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Splits the current string value by given split character or string. Ex: code.coding.first().code.utl:split('-')",
-    insertText = "utl:split(<splitCharExpr>)",detail = "utl", label = "utl:split", kind = "Method")
+    insertText = "utl:split(<splitCharExpr>)",detail = "utl", label = "utl:split", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def split(splitCharExpr: ExpressionContext): Seq[FhirPathResult] = {
 
     val splitChar =
@@ -501,7 +502,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Takes the prefix of a string until one of the given stop character. Ex: 'VERY LOW.'.utl:takeUntil('.' | '*')",
-    insertText = "utl:takeUntil(<stopCharExpr>)",detail = "utl", label = "utl:takeUntil", kind = "Method")
+    insertText = "utl:takeUntil(<stopCharExpr>)",detail = "utl", label = "utl:takeUntil", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def takeUntil(stopCharExpr: ExpressionContext): Seq[FhirPathResult] = {
     val stopChars: Set[Char] =
       (new FhirPathExpressionEvaluator(context, current)
@@ -525,7 +526,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Creates a list of numbers. Ex: utl:indices(1, 10)",
-    insertText = "utl:indices(<startnumber>, <endnumber>)",detail = "utl", label = "utl:indices", kind = "Function")
+    insertText = "utl:indices(<startnumber>, <endnumber>)",detail = "utl", label = "utl:indices", kind = "Function", returnType = Seq("integer"), inputType = Seq())
   def indices(fromExpr: ExpressionContext, toExpr: ExpressionContext): Seq[FhirPathResult] = {
     val from = new FhirPathExpressionEvaluator(context, current).visit(fromExpr)
     if (from.length != 1 || !from.forall(_.isInstanceOf[FhirPathNumber]))
@@ -546,7 +547,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Returns the indices (starting from 1) in the current sequence of results where given expression returns true. Ex: Observation.code.coding.utl:indicesWhere($this.system='http://snomed.info/sct')",
-    insertText = "utl:indicesWhere(<condExpr>)",detail = "utl", label = "utl:indicesWhere", kind = "Method")
+    insertText = "utl:indicesWhere(<condExpr>)",detail = "utl", label = "utl:indicesWhere", kind = "Method", returnType = Seq("integer"), inputType = Seq())
   def indicesWhere(condExpr: ExpressionContext): Seq[FhirPathResult] = {
     current
       .zipWithIndex
@@ -566,7 +567,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Combines current string results with the given separator and return a string. Ex: code.mkString(' | ')",
-    insertText = "utl:mkString(<separatorExp>)",detail = "utl", label = "utl:mkString", kind = "Method")
+    insertText = "utl:mkString(<separatorExp>)",detail = "utl", label = "utl:mkString", kind = "Method", returnType = Seq("string"), inputType = Seq("string"))
   def mkString(separatorExp: ExpressionContext): Seq[FhirPathResult] = {
     if (!current.forall(_.isInstanceOf[FhirPathString]))
       throw new FhirPathException(s"Invalid function call 'mkString' on non string value(s)!")
@@ -592,7 +593,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Evaluates expression. Ex: utl:evaluateExpression('1 + 1')",
-    insertText = "utl:evaluateExpression(<expression>)",detail = "utl", label = "utl:evaluateExpression", kind = "Function")
+    insertText = "utl:evaluateExpression(<expression>)",detail = "utl", label = "utl:evaluateExpression", kind = "Function", returnType = Seq(), inputType = Seq())
   def evaluateExpression(fhirPathExpression: ExpressionContext): Seq[FhirPathResult] = {
     val fhirPath = new FhirPathExpressionEvaluator(context, current).visit(fhirPathExpression)
     if (fhirPath.length != 1 || !fhirPath.forall(_.isInstanceOf[FhirPathString]))
@@ -615,7 +616,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Throws a FHIR Path exception with the given msg.",
-    insertText = "utl:throwException(<msgExpr>)",detail = "utl", label = "utl:throwException", kind = "Function")
+    insertText = "utl:throwException(<msgExpr>)",detail = "utl", label = "utl:throwException", kind = "Function", returnType = Seq(), inputType = Seq())
   def throwException(msgExpr: ExpressionContext): Seq[FhirPathResult] = {
     val excMsg = new FhirPathExpressionEvaluator(context, current).visit(msgExpr)
     if (excMsg.length != 1 || !excMsg.head.isInstanceOf[FhirPathString])
@@ -632,7 +633,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Returns a period between the FHIR date time given in current and  FHIR date time given in first expression. Ex: effectivePeriod.utl:getPeriod(start, @2020-09-07T10:00:00Z, 'years')",
-    insertText = "utl:getPeriod(<fromDate>, <toDate>, <period>)",detail = "utl", label = "utl:getPeriod", kind = "Method")
+    insertText = "utl:getPeriod(<fromDate>, <toDate>, <period>)",detail = "utl", label = "utl:getPeriod", kind = "Method", returnType = Seq("number"), inputType = Seq("dateTime"))
   def getPeriod(fromDate: ExpressionContext, toDate: ExpressionContext, period: ExpressionContext): Seq[FhirPathResult] = {
     val fdate: Option[Temporal] = new FhirPathExpressionEvaluator(context, current).visit(fromDate) match {
       case Seq(FhirPathDateTime(dt)) => Some(dt)
@@ -680,7 +681,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts it to a custom date string.",
-    insertText = "utl:toFhirDate(<sourcePattern>)",detail = "utl", label = "utl:toFhirDate", kind = "Method")
+    insertText = "utl:toFhirDate(<sourcePattern>)",detail = "utl", label = "utl:toFhirDate", kind = "Method", returnType = Seq("dateTime"), inputType = Seq("string"))
   def toFhirDate(sourcePattern: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -710,7 +711,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME). Ex: '2012-01-13 22:10:45'.utl:toFhirDateTime()",
-    insertText = "utl:toFhirDateTime()",detail = "utl", label = "utl:toFhirDateTime", kind = "Method")
+    insertText = "utl:toFhirDateTime()",detail = "utl", label = "utl:toFhirDateTime", kind = "Method", returnType = Seq("dateTime"), inputType = Seq("string"))
   def toFhirDateTime(): Seq[FhirPathResult] = {
     val patternsToTry = Seq("yyyy-MM-dd HH:mm:ss", "yyyy-MM-ddHH:mm:ss")
     _toFhirDateTime(patternsToTry)
@@ -724,7 +725,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME). Ex: '20120113.22:10:45'.utl:toFhirDateTime('yyyy-MM-ddHH:mm:ss' | 'yyyyMMdd.HH:mm:ss')",
-    insertText = "utl:toFhirDateTime(<system>)",detail = "utl", label = "utl:toFhirDateTime", kind = "Method")
+    insertText = "utl:toFhirDateTime(<system>)",detail = "utl", label = "utl:toFhirDateTime", kind = "Method", returnType = Seq("dateTime"), inputType = Seq("string"))
   def toFhirDateTime(sourcePattern: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -742,7 +743,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "Converts the current string value to string representation of Fhir DateTime format (ISO DATE TIME) with the given time zone",
-    insertText = "utl:toFhirDateTime(<sourcePattern>, <zoneId>)",detail = "utl", label = "utl:toFhirDateTime", kind = "Method")
+    insertText = "utl:toFhirDateTime(<sourcePattern>, <zoneId>)",detail = "utl", label = "utl:toFhirDateTime", kind = "Method", returnType = Seq("dateTime"), inputType = Seq("string"))
   def toFhirDateTime(sourcePattern: ExpressionContext, zoneId: ExpressionContext): Seq[FhirPathResult] = {
     val pattern = new FhirPathExpressionEvaluator(context, current).visit(sourcePattern)
     if (pattern.isEmpty || !pattern.forall(_.isInstanceOf[FhirPathString])) {
@@ -792,7 +793,7 @@ class FhirPathUtilFunctions(context: FhirPathEnvironment, current: Seq[FhirPathR
    * @return
    */
   @FhirPathFunction(documentation = "For FHIR coding elements, filters the ones that match the given coding list as FHIR code query",
-    insertText = "utl:isCodingIn(<codingListExpr>)",detail = "utl", label = "utl:isCodingIn", kind = "Method")
+    insertText = "utl:isCodingIn(<codingListExpr>)",detail = "utl", label = "utl:isCodingIn", kind = "Method", returnType = Seq("boolean"), inputType = Seq())
   def isCodingIn(codingList: ExpressionContext): Seq[FhirPathResult] = {
     val systemAndCodes: Seq[(Option[String], Option[String])] = new FhirPathExpressionEvaluator(context, current).visit(codingList) match {
       case s: Seq[_] if s.forall(i => i.isInstanceOf[FhirPathString]) =>

--- a/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala
@@ -10,5 +10,8 @@ import scala.annotation.StaticAnnotation
  * @param insertText    A string or snippet that should be inserted in a document when selecting this completion.
  * @param detail        The library prefix to which FhirPath function belongs.
  * @param label         The label (i.e. name) of function.
+ * @param kind          The type of function. It can be one of the followings:
+ *                        - Method: FhirPath functions that operate on a collection of values (i.e. input collection) such as name.exists()
+ *                        - Function: FhirPath functions that do not need an input collection such as today()
  */
-class FhirPathFunction(val documentation: String, val insertText: String, val detail: String, val label: String) extends StaticAnnotation
+class FhirPathFunction(val documentation: String, val insertText: String, val detail: String, val label: String, val kind: String) extends StaticAnnotation

--- a/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala
+++ b/onfhir-path/src/main/scala/io/onfhir/path/annotation/FhirPathFunction.scala
@@ -13,5 +13,15 @@ import scala.annotation.StaticAnnotation
  * @param kind          The type of function. It can be one of the followings:
  *                        - Method: FhirPath functions that operate on a collection of values (i.e. input collection) such as name.exists()
  *                        - Function: FhirPath functions that do not need an input collection such as today()
+ * @param returnType    Possible return types of a function / method. It could be an empty sequence indicating that it returns a collection of any data types.
+ * @param inputType     Possible input types of a method. It could be an empty sequence indicating that it accepts a collection of any data types.
+ *                      For functions (i.e. the ones whose kind are 'Function'), it should be an empty sequence because they do not need any input collection to run.
  */
-class FhirPathFunction(val documentation: String, val insertText: String, val detail: String, val label: String, val kind: String) extends StaticAnnotation
+class FhirPathFunction(val documentation: String,
+                       val insertText: String,
+                       val detail: String,
+                       val label: String,
+                       val kind: String,
+                       val returnType: Seq[String],
+                       val inputType: Seq[String]
+) extends StaticAnnotation


### PR DESCRIPTION
Extend FhirPathFunction annotation with the following fields:

-  **kind**          The type of function. It can be one of the followings:
                         - Method: FhirPath functions that operate on a collection of values (i.e. input collection) such as name.exists()
                         - Function: FhirPath functions that do not need an input collection such as today()

-   **returnType**    Possible return types of a function / method. It could be an empty sequence indicating that it returns a collection of any data types.

-  **inputType**   Possible input types of a method. It could be an empty sequence indicating that it accepts a collection of any data types.For functions (i.e. the ones whose kind are 'Function'), it should be an empty sequence because they do not need any input collection to run.